### PR TITLE
Non repetitive syntax

### DIFF
--- a/src/z3.html
+++ b/src/z3.html
@@ -10,6 +10,7 @@
 
 <!-- Favicon -->
 <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AAAAAAUAAAAF////AP///wD///8A////AP///wD///8A////AP///wD///8A////AAAAAAIAAABbAAAAlQAAAKIAAACbAAAAmwAAAKIAAACVAAAAWwAAAAL///8A////AP///wD///8A////AAAAABQAAADAAAAAYwAAAA3///8A////AP///wD///8AAAAADQAAAGMAAADAAAAAFP///wD///8A////AP///wAAAACdAAAAOv///wD///8A////AP///wD///8A////AP///wD///8AAAAAOgAAAJ3///8A////AP///wAAAAAnAAAAcP///wAAAAAoAAAASv///wD///8A////AP///wAAAABKAAAAKP///wAAAABwAAAAJ////wD///8AAAAAgQAAABwAAACIAAAAkAAAAJMAAACtAAAAFQAAABUAAACtAAAAkwAAAJAAAACIAAAAHAAAAIH///8A////AAAAAKQAAACrAAAAaP///wD///8AAAAARQAAANIAAADSAAAARf///wD///8AAAAAaAAAAKsAAACk////AAAAADMAAACcAAAAnQAAABj///8A////AP///wAAAAAYAAAAGP///wD///8A////AAAAABgAAACdAAAAnAAAADMAAAB1AAAAwwAAAP8AAADpAAAAsQAAAE4AAAAb////AP///wAAAAAbAAAATgAAALEAAADpAAAA/wAAAMMAAAB1AAAAtwAAAOkAAAD/AAAA/wAAAP8AAADvAAAA3gAAAN4AAADeAAAA3gAAAO8AAAD/AAAA/wAAAP8AAADpAAAAtwAAAGUAAAA/AAAA3wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAADfAAAAPwAAAGX///8A////AAAAAEgAAADtAAAAvwAAAL0AAADGAAAA7wAAAO8AAADGAAAAvQAAAL8AAADtAAAASP///wD///8A////AP///wD///8AAAAAO////wD///8A////AAAAAIcAAACH////AP///wD///8AAAAAO////wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A//8AAP//AAD4HwAA7/cAAN/7AAD//wAAoYUAAJ55AACf+QAAh+EAAAAAAADAAwAA4AcAAP5/AAD//wAA//8AAA=="/>
+<link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA3XAAAN1wFCKJt4AAAAB3RJTUUH4QQQEwksSS9ZWwAAAk1JREFUWMPtll2ITVEUx39nn/O7Y5qR8f05wtCUUr6ZIS++8pEnkZInPImneaCQ5METNdOkeFBKUhMPRIkHKfEuUZSUlGlKPN2TrgfncpvmnntnmlEyq1Z7t89/rf9a6+y99oZxGZf/XeIq61EdtgKXgdXA0xrYAvBjOIF1AI9zvjcC74BSpndrJPkBWDScTF8Aa4E3wDlgHbASaANmVqlcCnwHvgDvgVfAJ+AikAAvgfVZwLnSVZHZaOuKoQi3ZOMi4NkYkpe1p4J7A8BpYAD49hfIy/oqG0+hLomiKP2L5L+1ubn5115S+3OAn4EnwBlgMzCjyt6ZAnQCJ4A7wOs88iRJHvw50HoujuPBoCKwHWiosy8MdfZnAdcHk8dxXFJ3VQbQlCTJvRBCGdRbD4M6uc5glpY3eAihpN5S5w12diSEcCCEcKUO4ljdr15T76ur1FDDLIQQ3qv71EdDOe3Kxj3leRXyk+pxdWnFWod6Wt2bY3de3aSuUHcPBVimHs7mK9WrmeOF6lR1o9qnzskh2ar2qm1qizpfXaPeVGdlmGN5pb09qMxz1Xb1kLqgzn1RyH7JUXW52lr5e/Kqi9qpto7V1atuUzfnARrV7jEib1T76gG2qxdGmXyiekkt1GswPTtek0aBfJp6YySGBfWg2tPQ0FAYgf1stUfdmdcjarbYJEniKIq6gY/Aw+zWHAC+p2labGpqiorFYgGYCEzN7oQdQClN07O1/EfDyGgC0ALMBdYAi4FyK+4H3gLPsxfR1zRNi+NP7nH5J+QntnXe5B5mpfQAAAAASUVORK5CYII=">
 
 <!-- Google fonts -->
 <link href='https://fonts.googleapis.com/css?family=Lato:400,600,900' rel='stylesheet' type='text/css'/>
@@ -99,6 +100,23 @@ input#searchInput {
   width: 80%;
 }
 
+/*
+ * Some custom formatting for input forms.
+ * This also fixes input form colors on Firefox with a dark system theme on Linux.
+ */
+input {
+  -moz-appearance: none;
+  color: #333;
+  background-color: #f8f8f8;
+  border: 1px solid #aaa;
+  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  padding: 6px;
+}
+input:focus {
+  border: 1px solid #1fa0eb;
+  box-shadow: 0 0 2px #1fa0eb;
+}
 
 /* Docgen styles */
 /* Links */
@@ -345,11 +363,11 @@ dl {
 
 dt {
   margin-bottom: -0.5em;
-  margin-left: 0.5em; }
+  margin-left: 0.0em; }
 
 dd {
-  margin-left: 0.5em;
-  margin-bottom: 2.5em;
+  margin-left: 2.0em;
+  margin-bottom: 3.0em;
   margin-top: 0.5em; }
 
 
@@ -761,6 +779,10 @@ span.pragmawrap {
   display: none;
 }
 
+span.attachedType {
+  display: none;
+  visibility: hidden;
+}
 </style>
 
 <script type="text/javascript" src="dochack.js"></script>
@@ -807,12 +829,6 @@ function main() {
 <li><a class="reference" id="z3-z3-ast-types_toc" href="#z3-z3-ast-types">Z3 AST types</a></li>
 <li><a class="reference" id="z3-operators_toc" href="#z3-operators">Operators</a></li>
 </ul><li>
-  <a class="reference reference-toplevel" href="#5" id="55">Exports</a>
-  <ul class="simple simple-toc-section">
-    
-  </ul>
-</li>
-<li>
   <a class="reference reference-toplevel" href="#6" id="56">Imports</a>
   <ul class="simple simple-toc-section">
     
@@ -822,15 +838,23 @@ function main() {
   <a class="reference reference-toplevel" href="#7" id="57">Types</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#Z3Exception"
-    title="Z3Exception = object of Exception"><wbr />Z3Exception<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="Z3Exception = object of Exception"><wbr />Z3Exception<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#Z3_ast_bool"
-    title="Z3_ast_bool = distinct Z3_ast"><wbr />Z3_<wbr />ast_<wbr />bool<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="Z3_ast_bool = distinct Z3_ast"><wbr />Z3_<wbr />ast_<wbr />bool<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#Z3_ast_bv"
-    title="Z3_ast_bv = distinct Z3_ast"><wbr />Z3_<wbr />ast_<wbr />bv<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="Z3_ast_bv = distinct Z3_ast"><wbr />Z3_<wbr />ast_<wbr />bv<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#Z3_ast_int"
-    title="Z3_ast_int = distinct Z3_ast"><wbr />Z3_<wbr />ast_<wbr />int<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="Z3_ast_int = distinct Z3_ast"><wbr />Z3_<wbr />ast_<wbr />int<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#Z3_ast_fpa"
-    title="Z3_ast_fpa = distinct Z3_ast"><wbr />Z3_<wbr />ast_<wbr />fpa<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="Z3_ast_fpa = distinct Z3_ast"><wbr />Z3_<wbr />ast_<wbr />fpa<span class="attachedType"></span></a></li>
+
+  </ul>
+</li>
+<li>
+  <a class="reference reference-toplevel" href="#17" id="67">Macros</a>
+  <ul class="simple simple-toc-section">
+      <li><a class="reference" href="#letZ3.m%2Cuntyped%2Cuntyped"
+    title="letZ3(name: untyped; sort: untyped)"><wbr />let<wbr />Z3<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -838,366 +862,412 @@ function main() {
   <a class="reference reference-toplevel" href="#18" id="68">Templates</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#Bool.t%2Cstring"
-    title="Bool(name: string): Z3_ast_bool"><wbr />Bool<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="Bool(name: string): Z3_ast_bool"><wbr />Bool<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#Int.t%2Cstring"
-    title="Int(name: string): Z3_ast_int"><wbr />Int<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="Int(name: string): Z3_ast_int"><wbr />Int<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#Bv.t%2Cstring%2Cint"
-    title="Bv(name: string; sz: int): Z3_ast_bv"><wbr />Bv<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="Bv(name: string; sz: int): Z3_ast_bv"><wbr />Bv<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#Float.t%2Cstring"
-    title="Float(name: string): Z3_ast_fpa"><wbr />Float<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="Float(name: string): Z3_ast_fpa"><wbr />Float<span class="attachedType">Z3_ast_fpa</span></a></li>
+  <li><a class="reference" href="#letBool.t"
+    title="letBool(args: varargs[untyped])"><wbr />let<wbr />Bool<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#letInt.t"
+    title="letInt(args: varargs[untyped])"><wbr />let<wbr />Int<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#letBv.t"
+    title="letBv(args: varargs[untyped])"><wbr />let<wbr />Bv<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#letFloat.t"
+    title="letFloat(args: varargs[untyped])"><wbr />let<wbr />Float<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#%24.t%2CZ3_ast_any"
-    title="`$`(v: Z3_ast_any): string"><wbr />`$`<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="`$`(v: Z3_ast_any): string"><wbr />`$`<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#%24.t%2CZ3_model"
-    title="`$`(m: Z3_model): string"><wbr />`$`<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="`$`(m: Z3_model): string"><wbr />`$`<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#%24.t%2CZ3_solver"
-    title="`$`(m: Z3_solver): string"><wbr />`$`<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="`$`(m: Z3_solver): string"><wbr />`$`<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#%24.t%2CZ3_optimize"
+    title="`$`(m: Z3_optimize): string"><wbr />`$`<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#%24.t%2CZ3_pattern"
+    title="`$`(m: Z3_pattern): string"><wbr />`$`<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#simplify.t%2CZ3_ast_any"
-    title="simplify(s: Z3_ast_any): Z3_ast"><wbr />simplify<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="simplify(s: Z3_ast_any): Z3_ast"><wbr />simplify<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#Solver.t"
-    title="Solver(): Z3_solver"><wbr />Solver<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="Solver(): Z3_solver"><wbr />Solver<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#assert.t%2CZ3_solver%2CZ3_ast_any"
-    title="assert(s: Z3_solver; e: Z3_ast_any)"><wbr />assert<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="assert(s: Z3_solver; e: Z3_ast_any)"><wbr />assert<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#check.t%2CZ3_solver"
-    title="check(s: Z3_solver): Z3_lbool"><wbr />check<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="check(s: Z3_solver): Z3_lbool"><wbr />check<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#get_model.t%2CZ3_solver"
-    title="get_model(s: Z3_solver): Z3_model"><wbr />get_<wbr />model<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="get_model(s: Z3_solver): Z3_model"><wbr />get_<wbr />model<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#push.t%2CZ3_solver%2Cuntyped"
-    title="push(s: Z3_solver; code: untyped)"><wbr />push<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="push(s: Z3_solver; code: untyped)"><wbr />push<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#check_model.t%2CZ3_solver%2Cuntyped"
-    title="check_model(s: Z3_solver; code: untyped)"><wbr />check_<wbr />model<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="check_model(s: Z3_solver; code: untyped)"><wbr />check_<wbr />model<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#Optimizer.t"
-    title="Optimizer(): Z3_optimize"><wbr />Optimizer<span class="attachedType" style="visibility:hidden"></span></a></li>
-  <li><a class="reference" href="#minimize.t%2CZ3_optimize%2CZ3_ast"
-    title="minimize(o: Z3_optimize; e: Z3_ast)"><wbr />minimize<span class="attachedType" style="visibility:hidden"></span></a></li>
-  <li><a class="reference" href="#maximize.t%2CZ3_optimize%2CZ3_ast"
-    title="maximize(o: Z3_optimize; e: Z3_ast)"><wbr />maximize<span class="attachedType" style="visibility:hidden"></span></a></li>
-  <li><a class="reference" href="#assert.t%2CZ3_optimize%2CZ3_ast"
-    title="assert(o: Z3_optimize; e: Z3_ast)"><wbr />assert<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="Optimizer(): Z3_optimize"><wbr />Optimizer<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#minimize.t%2CZ3_optimize%2CZ3_ast_any"
+    title="minimize(o: Z3_optimize; e: Z3_ast_any)"><wbr />minimize<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#maximize.t%2CZ3_optimize%2CZ3_ast_any"
+    title="maximize(o: Z3_optimize; e: Z3_ast_any)"><wbr />maximize<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#assert.t%2CZ3_optimize%2CZ3_ast_any"
+    title="assert(o: Z3_optimize; e: Z3_ast_any)"><wbr />assert<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#check.t%2CZ3_optimize"
+    title="check(s: Z3_optimize): Z3_lbool"><wbr />check<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#get_model.t%2CZ3_optimize"
+    title="get_model(s: Z3_optimize): Z3_model"><wbr />get_<wbr />model<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#check_model.t%2CZ3_optimize%2Cuntyped"
+    title="check_model(s: Z3_optimize; code: untyped)"><wbr />check_<wbr />model<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#eval.t%2CZ3_ast_any"
-    title="eval(v: Z3_ast_any): Z3_ast"><wbr />eval<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="eval(v: Z3_ast_any): Z3_ast"><wbr />eval<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#evalInt.t%2CZ3_ast_any"
-    title="evalInt(v: Z3_ast_any): int"><wbr />eval<wbr />Int<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="evalInt(v: Z3_ast_any): int"><wbr />eval<wbr />Int<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#evalFloat.t%2CZ3_ast_any"
-    title="evalFloat(v: Z3_ast_any): float"><wbr />eval<wbr />Float<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="evalFloat(v: Z3_ast_any): float"><wbr />eval<wbr />Float<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#z3.t%2Cuntyped"
-    title="z3(code: untyped)"><wbr />z3<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="z3(code: untyped)"><wbr />z3<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#and.t%2CZ3_ast_bool%2CZ3_ast_bool"
-    title="`and`(a1: Z3_ast_bool; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`and`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`and`(a1`gensym260516, a2`gensym260517: Z3_ast_bool): Z3_ast_bool"><wbr />`and`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#and.t%2CZ3_ast_bool%2CT"
-    title="`and`[T](a1: Z3_ast_bool; a2: T): Z3_ast_bool"><wbr />`and`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`and`[T](a1`gensym260518: Z3_ast_bool; a2`gensym260519: T): Z3_ast_bool"><wbr />`and`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#and.t%2CT%2CZ3_ast_bool"
-    title="`and`[T](a1: T; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`and`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`and`[T](a1`gensym260520: T; a2`gensym260521: Z3_ast_bool): Z3_ast_bool"><wbr />`and`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#or.t%2CZ3_ast_bool%2CZ3_ast_bool"
-    title="`or`(a1: Z3_ast_bool; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`or`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`or`(a1`gensym260543, a2`gensym260544: Z3_ast_bool): Z3_ast_bool"><wbr />`or`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#or.t%2CZ3_ast_bool%2CT"
-    title="`or`[T](a1: Z3_ast_bool; a2: T): Z3_ast_bool"><wbr />`or`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`or`[T](a1`gensym260545: Z3_ast_bool; a2`gensym260546: T): Z3_ast_bool"><wbr />`or`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#or.t%2CT%2CZ3_ast_bool"
-    title="`or`[T](a1: T; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`or`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`or`[T](a1`gensym260547: T; a2`gensym260548: Z3_ast_bool): Z3_ast_bool"><wbr />`or`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#xor.t%2CZ3_ast_bool%2CZ3_ast_bool"
-    title="`xor`(a1: Z3_ast_bool; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`xor`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`xor`(a1`gensym260570, a2`gensym260571: Z3_ast_bool): Z3_ast_bool"><wbr />`xor`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#xor.t%2CZ3_ast_bool%2CT"
-    title="`xor`[T](a1: Z3_ast_bool; a2: T): Z3_ast_bool"><wbr />`xor`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`xor`[T](a1`gensym260572: Z3_ast_bool; a2`gensym260573: T): Z3_ast_bool"><wbr />`xor`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#xor.t%2CT%2CZ3_ast_bool"
-    title="`xor`[T](a1: T; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`xor`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`xor`[T](a1`gensym260574: T; a2`gensym260575: Z3_ast_bool): Z3_ast_bool"><wbr />`xor`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CZ3_ast_bool%2CZ3_ast_bool"
-    title="`==`(a1: Z3_ast_bool; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`==`(a1`gensym260597, a2`gensym260598: Z3_ast_bool): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CZ3_ast_bool%2CT"
-    title="`==`[T](a1: Z3_ast_bool; a2: T): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`==`[T](a1`gensym260599: Z3_ast_bool; a2`gensym260600: T): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CT%2CZ3_ast_bool"
-    title="`==`[T](a1: T; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`==`[T](a1`gensym260601: T; a2`gensym260602: Z3_ast_bool): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_bool%2CZ3_ast_bool"
-    title="`&lt;-&gt;`(a1: Z3_ast_bool; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;-&gt;`(a1`gensym260624, a2`gensym260625: Z3_ast_bool): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_bool%2CT"
-    title="`&lt;-&gt;`[T](a1: Z3_ast_bool; a2: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym260626: Z3_ast_bool; a2`gensym260627: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CT%2CZ3_ast_bool"
-    title="`&lt;-&gt;`[T](a1: T; a2: Z3_ast_bool): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym260628: T; a2`gensym260629: Z3_ast_bool): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#not.t%2CZ3_ast_bool"
-    title="`not`(a: Z3_ast_bool): Z3_ast_bool"><wbr />`not`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`not`(a`gensym260651: Z3_ast_bool): Z3_ast_bool"><wbr />`not`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#and.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`and`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`and`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`and`(a1`gensym260656, a2`gensym260657: Z3_ast_bv): Z3_ast_bv"><wbr />`and`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#and.t%2CZ3_ast_bv%2CT"
-    title="`and`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`and`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`and`[T](a1`gensym260658: Z3_ast_bv; a2`gensym260659: T): Z3_ast_bv"><wbr />`and`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#and.t%2CT%2CZ3_ast_bv"
-    title="`and`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`and`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`and`[T](a1`gensym260660: T; a2`gensym260661: Z3_ast_bv): Z3_ast_bv"><wbr />`and`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#mod.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`mod`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`mod`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`mod`(a1`gensym260683, a2`gensym260684: Z3_ast_bv): Z3_ast_bv"><wbr />`mod`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#mod.t%2CZ3_ast_bv%2CT"
-    title="`mod`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`mod`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`mod`[T](a1`gensym260685: Z3_ast_bv; a2`gensym260686: T): Z3_ast_bv"><wbr />`mod`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#mod.t%2CT%2CZ3_ast_bv"
-    title="`mod`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`mod`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`mod`[T](a1`gensym260687: T; a2`gensym260688: Z3_ast_bv): Z3_ast_bv"><wbr />`mod`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#nor.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="nor(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />nor<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="nor(a1`gensym260710, a2`gensym260711: Z3_ast_bv): Z3_ast_bv"><wbr />nor<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#nor.t%2CZ3_ast_bv%2CT"
-    title="nor[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />nor<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="nor[T](a1`gensym260712: Z3_ast_bv; a2`gensym260713: T): Z3_ast_bv"><wbr />nor<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#nor.t%2CT%2CZ3_ast_bv"
-    title="nor[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />nor<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="nor[T](a1`gensym260714: T; a2`gensym260715: Z3_ast_bv): Z3_ast_bv"><wbr />nor<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#or.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`or`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`or`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`or`(a1`gensym260737, a2`gensym260738: Z3_ast_bv): Z3_ast_bv"><wbr />`or`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#or.t%2CZ3_ast_bv%2CT"
-    title="`or`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`or`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`or`[T](a1`gensym260739: Z3_ast_bv; a2`gensym260740: T): Z3_ast_bv"><wbr />`or`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#or.t%2CT%2CZ3_ast_bv"
-    title="`or`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`or`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`or`[T](a1`gensym260741: T; a2`gensym260742: Z3_ast_bv): Z3_ast_bv"><wbr />`or`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#shl.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`shl`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`shl`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`shl`(a1`gensym260764, a2`gensym260765: Z3_ast_bv): Z3_ast_bv"><wbr />`shl`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#shl.t%2CZ3_ast_bv%2CT"
-    title="`shl`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`shl`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`shl`[T](a1`gensym260766: Z3_ast_bv; a2`gensym260767: T): Z3_ast_bv"><wbr />`shl`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#shl.t%2CT%2CZ3_ast_bv"
-    title="`shl`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`shl`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`shl`[T](a1`gensym260768: T; a2`gensym260769: Z3_ast_bv): Z3_ast_bv"><wbr />`shl`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#shr.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`shr`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`shr`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`shr`(a1`gensym260791, a2`gensym260792: Z3_ast_bv): Z3_ast_bv"><wbr />`shr`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#shr.t%2CZ3_ast_bv%2CT"
-    title="`shr`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`shr`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`shr`[T](a1`gensym260793: Z3_ast_bv; a2`gensym260794: T): Z3_ast_bv"><wbr />`shr`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#shr.t%2CT%2CZ3_ast_bv"
-    title="`shr`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`shr`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`shr`[T](a1`gensym260795: T; a2`gensym260796: Z3_ast_bv): Z3_ast_bv"><wbr />`shr`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#xnor.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="xnor(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />xnor<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="xnor(a1`gensym260818, a2`gensym260819: Z3_ast_bv): Z3_ast_bv"><wbr />xnor<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#xnor.t%2CZ3_ast_bv%2CT"
-    title="xnor[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />xnor<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="xnor[T](a1`gensym260820: Z3_ast_bv; a2`gensym260821: T): Z3_ast_bv"><wbr />xnor<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#xnor.t%2CT%2CZ3_ast_bv"
-    title="xnor[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />xnor<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="xnor[T](a1`gensym260822: T; a2`gensym260823: Z3_ast_bv): Z3_ast_bv"><wbr />xnor<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#xor.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`xor`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`xor`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`xor`(a1`gensym260845, a2`gensym260846: Z3_ast_bv): Z3_ast_bv"><wbr />`xor`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#xor.t%2CZ3_ast_bv%2CT"
-    title="`xor`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`xor`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`xor`[T](a1`gensym260847: Z3_ast_bv; a2`gensym260848: T): Z3_ast_bv"><wbr />`xor`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#xor.t%2CT%2CZ3_ast_bv"
-    title="`xor`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`xor`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`xor`[T](a1`gensym260849: T; a2`gensym260850: Z3_ast_bv): Z3_ast_bv"><wbr />`xor`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3E%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`&gt;=`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&gt;=`(a1`gensym260872, a2`gensym260873: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3E%3D.t%2CZ3_ast_bv%2CT"
-    title="`&gt;=`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&gt;=`[T](a1`gensym260874: Z3_ast_bv; a2`gensym260875: T): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3E%3D.t%2CT%2CZ3_ast_bv"
-    title="`&gt;=`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&gt;=`[T](a1`gensym260876: T; a2`gensym260877: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3E.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`&gt;`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&gt;`(a1`gensym260899, a2`gensym260900: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3E.t%2CZ3_ast_bv%2CT"
-    title="`&gt;`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&gt;`[T](a1`gensym260901: Z3_ast_bv; a2`gensym260902: T): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3E.t%2CT%2CZ3_ast_bv"
-    title="`&gt;`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&gt;`[T](a1`gensym260903: T; a2`gensym260904: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`&lt;=`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&lt;=`(a1`gensym260926, a2`gensym260927: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3C%3D.t%2CZ3_ast_bv%2CT"
-    title="`&lt;=`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&lt;=`[T](a1`gensym260928: Z3_ast_bv; a2`gensym260929: T): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3C%3D.t%2CT%2CZ3_ast_bv"
-    title="`&lt;=`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;=`[T](a1`gensym260930: T; a2`gensym260931: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`&lt;`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&lt;`(a1`gensym260953, a2`gensym260954: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3C.t%2CZ3_ast_bv%2CT"
-    title="`&lt;`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&lt;`[T](a1`gensym260955: Z3_ast_bv; a2`gensym260956: T): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3C.t%2CT%2CZ3_ast_bv"
-    title="`&lt;`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
-  <li><a class="reference" href="#%25%3E%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`%&gt;=`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`%&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
-  <li><a class="reference" href="#%25%3E%3D.t%2CZ3_ast_bv%2CT"
-    title="`%&gt;=`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`%&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
-  <li><a class="reference" href="#%25%3E%3D.t%2CT%2CZ3_ast_bv"
-    title="`%&gt;=`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`%&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
-  <li><a class="reference" href="#%25%3E.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`%&gt;`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`%&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
-  <li><a class="reference" href="#%25%3E.t%2CZ3_ast_bv%2CT"
-    title="`%&gt;`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`%&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
-  <li><a class="reference" href="#%25%3E.t%2CT%2CZ3_ast_bv"
-    title="`%&gt;`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`%&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
-  <li><a class="reference" href="#%25%3C%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`%&lt;=`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`%&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
-  <li><a class="reference" href="#%25%3C%3D.t%2CZ3_ast_bv%2CT"
-    title="`%&lt;=`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`%&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
-  <li><a class="reference" href="#%25%3C%3D.t%2CT%2CZ3_ast_bv"
-    title="`%&lt;=`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`%&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
-  <li><a class="reference" href="#%25%3C.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`%&lt;`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`%&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
-  <li><a class="reference" href="#%25%3C.t%2CZ3_ast_bv%2CT"
-    title="`%&lt;`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`%&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
-  <li><a class="reference" href="#%25%3C.t%2CT%2CZ3_ast_bv"
-    title="`%&lt;`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`%&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;`[T](a1`gensym260957: T; a2`gensym260958: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType">Z3_ast_bool</span></a></li>
+  <li><a class="reference" href="#%3E%3D%25.t%2CZ3_ast_bv%2CZ3_ast_bv"
+    title="`&gt;=%`(a1`gensym260980, a2`gensym260981: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;=%`<span class="attachedType">Z3_ast_bv</span></a></li>
+  <li><a class="reference" href="#%3E%3D%25.t%2CZ3_ast_bv%2CT"
+    title="`&gt;=%`[T](a1`gensym260982: Z3_ast_bv; a2`gensym260983: T): Z3_ast_bool"><wbr />`&gt;=%`<span class="attachedType">Z3_ast_bv</span></a></li>
+  <li><a class="reference" href="#%3E%3D%25.t%2CT%2CZ3_ast_bv"
+    title="`&gt;=%`[T](a1`gensym260984: T; a2`gensym260985: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;=%`<span class="attachedType">Z3_ast_bool</span></a></li>
+  <li><a class="reference" href="#%3E%25.t%2CZ3_ast_bv%2CZ3_ast_bv"
+    title="`&gt;%`(a1`gensym261007, a2`gensym261008: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;%`<span class="attachedType">Z3_ast_bv</span></a></li>
+  <li><a class="reference" href="#%3E%25.t%2CZ3_ast_bv%2CT"
+    title="`&gt;%`[T](a1`gensym261009: Z3_ast_bv; a2`gensym261010: T): Z3_ast_bool"><wbr />`&gt;%`<span class="attachedType">Z3_ast_bv</span></a></li>
+  <li><a class="reference" href="#%3E%25.t%2CT%2CZ3_ast_bv"
+    title="`&gt;%`[T](a1`gensym261011: T; a2`gensym261012: Z3_ast_bv): Z3_ast_bool"><wbr />`&gt;%`<span class="attachedType">Z3_ast_bool</span></a></li>
+  <li><a class="reference" href="#%3C%3D%25.t%2CZ3_ast_bv%2CZ3_ast_bv"
+    title="`&lt;=%`(a1`gensym261034, a2`gensym261035: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;=%`<span class="attachedType">Z3_ast_bv</span></a></li>
+  <li><a class="reference" href="#%3C%3D%25.t%2CZ3_ast_bv%2CT"
+    title="`&lt;=%`[T](a1`gensym261036: Z3_ast_bv; a2`gensym261037: T): Z3_ast_bool"><wbr />`&lt;=%`<span class="attachedType">Z3_ast_bv</span></a></li>
+  <li><a class="reference" href="#%3C%3D%25.t%2CT%2CZ3_ast_bv"
+    title="`&lt;=%`[T](a1`gensym261038: T; a2`gensym261039: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;=%`<span class="attachedType">Z3_ast_bool</span></a></li>
+  <li><a class="reference" href="#%3C%25.t%2CZ3_ast_bv%2CZ3_ast_bv"
+    title="`&lt;%`(a1`gensym261061, a2`gensym261062: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;%`<span class="attachedType">Z3_ast_bv</span></a></li>
+  <li><a class="reference" href="#%3C%25.t%2CZ3_ast_bv%2CT"
+    title="`&lt;%`[T](a1`gensym261063: Z3_ast_bv; a2`gensym261064: T): Z3_ast_bool"><wbr />`&lt;%`<span class="attachedType">Z3_ast_bv</span></a></li>
+  <li><a class="reference" href="#%3C%25.t%2CT%2CZ3_ast_bv"
+    title="`&lt;%`[T](a1`gensym261065: T; a2`gensym261066: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;%`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`==`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`==`(a1`gensym261088, a2`gensym261089: Z3_ast_bv): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CZ3_ast_bv%2CT"
-    title="`==`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`==`[T](a1`gensym261090: Z3_ast_bv; a2`gensym261091: T): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CT%2CZ3_ast_bv"
-    title="`==`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`==`[T](a1`gensym261092: T; a2`gensym261093: Z3_ast_bv): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`&lt;-&gt;`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&lt;-&gt;`(a1`gensym261115, a2`gensym261116: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_bv%2CT"
-    title="`&lt;-&gt;`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym261117: Z3_ast_bv; a2`gensym261118: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CT%2CZ3_ast_bv"
-    title="`&lt;-&gt;`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym261119: T; a2`gensym261120: Z3_ast_bv): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%2B.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`+`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`+`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`+`(a1`gensym261142, a2`gensym261143: Z3_ast_bv): Z3_ast_bv"><wbr />`+`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2B.t%2CZ3_ast_bv%2CT"
-    title="`+`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`+`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`+`[T](a1`gensym261144: Z3_ast_bv; a2`gensym261145: T): Z3_ast_bv"><wbr />`+`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2B.t%2CT%2CZ3_ast_bv"
-    title="`+`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`+`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`+`[T](a1`gensym261146: T; a2`gensym261147: Z3_ast_bv): Z3_ast_bv"><wbr />`+`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2A.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`*`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`*`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`*`(a1`gensym261169, a2`gensym261170: Z3_ast_bv): Z3_ast_bv"><wbr />`*`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2A.t%2CZ3_ast_bv%2CT"
-    title="`*`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`*`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`*`[T](a1`gensym261171: Z3_ast_bv; a2`gensym261172: T): Z3_ast_bv"><wbr />`*`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2A.t%2CT%2CZ3_ast_bv"
-    title="`*`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`*`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`*`[T](a1`gensym261173: T; a2`gensym261174: Z3_ast_bv): Z3_ast_bv"><wbr />`*`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2F.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`&#x2F;`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`/`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`/`(a1`gensym261196, a2`gensym261197: Z3_ast_bv): Z3_ast_bv"><wbr />`/`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2F.t%2CZ3_ast_bv%2CT"
-    title="`&#x2F;`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`/`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`/`[T](a1`gensym261198: Z3_ast_bv; a2`gensym261199: T): Z3_ast_bv"><wbr />`/`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2F.t%2CT%2CZ3_ast_bv"
-    title="`&#x2F;`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`/`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`/`[T](a1`gensym261200: T; a2`gensym261201: Z3_ast_bv): Z3_ast_bv"><wbr />`/`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#-.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`-`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`-`(a1`gensym261223, a2`gensym261224: Z3_ast_bv): Z3_ast_bv"><wbr />`-`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#-.t%2CZ3_ast_bv%2CT"
-    title="`-`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`-`[T](a1`gensym261225: Z3_ast_bv; a2`gensym261226: T): Z3_ast_bv"><wbr />`-`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#-.t%2CT%2CZ3_ast_bv"
-    title="`-`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`-`[T](a1`gensym261227: T; a2`gensym261228: Z3_ast_bv): Z3_ast_bv"><wbr />`-`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2F%25.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`&#x2F;%`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`/%`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`/%`(a1`gensym261250, a2`gensym261251: Z3_ast_bv): Z3_ast_bv"><wbr />`/%`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2F%25.t%2CZ3_ast_bv%2CT"
-    title="`&#x2F;%`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`/%`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`/%`[T](a1`gensym261252: Z3_ast_bv; a2`gensym261253: T): Z3_ast_bv"><wbr />`/%`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%2F%25.t%2CT%2CZ3_ast_bv"
-    title="`&#x2F;%`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`/%`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`/%`[T](a1`gensym261254: T; a2`gensym261255: Z3_ast_bv): Z3_ast_bv"><wbr />`/%`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%26.t%2CZ3_ast_bv%2CZ3_ast_bv"
-    title="`&amp;`(a1: Z3_ast_bv; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`&amp;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&amp;`(a1`gensym261277, a2`gensym261278: Z3_ast_bv): Z3_ast_bv"><wbr />`&amp;`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%26.t%2CZ3_ast_bv%2CT"
-    title="`&amp;`[T](a1: Z3_ast_bv; a2: T): Z3_ast_bv"><wbr />`&amp;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&amp;`[T](a1`gensym261279: Z3_ast_bv; a2`gensym261280: T): Z3_ast_bv"><wbr />`&amp;`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%26.t%2CT%2CZ3_ast_bv"
-    title="`&amp;`[T](a1: T; a2: Z3_ast_bv): Z3_ast_bv"><wbr />`&amp;`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`&amp;`[T](a1`gensym261281: T; a2`gensym261282: Z3_ast_bv): Z3_ast_bv"><wbr />`&amp;`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#not.t%2CZ3_ast_bv"
-    title="`not`(a: Z3_ast_bv): Z3_ast_bv"><wbr />`not`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`not`(a`gensym261304: Z3_ast_bv): Z3_ast_bv"><wbr />`not`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#-.t%2CZ3_ast_bv"
-    title="`-`(a: Z3_ast_bv): Z3_ast_bv"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_bv</span></a></li>
+    title="`-`(a`gensym261309: Z3_ast_bv): Z3_ast_bv"><wbr />`-`<span class="attachedType">Z3_ast_bv</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`==`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`==`(a1`gensym261314, a2`gensym261315: Z3_ast_int): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CZ3_ast_int%2CT"
-    title="`==`[T](a1: Z3_ast_int; a2: T): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`==`[T](a1`gensym261316: Z3_ast_int; a2`gensym261317: T): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CT%2CZ3_ast_int"
-    title="`==`[T](a1: T; a2: Z3_ast_int): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`==`[T](a1`gensym261318: T; a2`gensym261319: Z3_ast_int): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3E%3D.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`&gt;=`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&gt;=`(a1`gensym261341, a2`gensym261342: Z3_ast_int): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3E%3D.t%2CZ3_ast_int%2CT"
-    title="`&gt;=`[T](a1: Z3_ast_int; a2: T): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&gt;=`[T](a1`gensym261343: Z3_ast_int; a2`gensym261344: T): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3E%3D.t%2CT%2CZ3_ast_int"
-    title="`&gt;=`[T](a1: T; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&gt;=`[T](a1`gensym261345: T; a2`gensym261346: Z3_ast_int): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3E.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`&gt;`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&gt;`(a1`gensym261368, a2`gensym261369: Z3_ast_int): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3E.t%2CZ3_ast_int%2CT"
-    title="`&gt;`[T](a1: Z3_ast_int; a2: T): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&gt;`[T](a1`gensym261370: Z3_ast_int; a2`gensym261371: T): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3E.t%2CT%2CZ3_ast_int"
-    title="`&gt;`[T](a1: T; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&gt;`[T](a1`gensym261372: T; a2`gensym261373: Z3_ast_int): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`&lt;-&gt;`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&lt;-&gt;`(a1`gensym261395, a2`gensym261396: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_int%2CT"
-    title="`&lt;-&gt;`[T](a1: Z3_ast_int; a2: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym261397: Z3_ast_int; a2`gensym261398: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CT%2CZ3_ast_int"
-    title="`&lt;-&gt;`[T](a1: T; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym261399: T; a2`gensym261400: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C%3D.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`&lt;=`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&lt;=`(a1`gensym261422, a2`gensym261423: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3C%3D.t%2CZ3_ast_int%2CT"
-    title="`&lt;=`[T](a1: Z3_ast_int; a2: T): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&lt;=`[T](a1`gensym261424: Z3_ast_int; a2`gensym261425: T): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3C%3D.t%2CT%2CZ3_ast_int"
-    title="`&lt;=`[T](a1: T; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;=`[T](a1`gensym261426: T; a2`gensym261427: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`&lt;`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&lt;`(a1`gensym261449, a2`gensym261450: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3C.t%2CZ3_ast_int%2CT"
-    title="`&lt;`[T](a1: Z3_ast_int; a2: T): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`&lt;`[T](a1`gensym261451: Z3_ast_int; a2`gensym261452: T): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3C.t%2CT%2CZ3_ast_int"
-    title="`&lt;`[T](a1: T; a2: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;`[T](a1`gensym261453: T; a2`gensym261454: Z3_ast_int): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%2B.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`+`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_int"><wbr />`+`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`+`(a1`gensym261476, a2`gensym261477: Z3_ast_int): Z3_ast_int"><wbr />`+`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%2B.t%2CZ3_ast_int%2CT"
-    title="`+`[T](a1: Z3_ast_int; a2: T): Z3_ast_int"><wbr />`+`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`+`[T](a1`gensym261478: Z3_ast_int; a2`gensym261479: T): Z3_ast_int"><wbr />`+`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%2B.t%2CT%2CZ3_ast_int"
-    title="`+`[T](a1: T; a2: Z3_ast_int): Z3_ast_int"><wbr />`+`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`+`[T](a1`gensym261480: T; a2`gensym261481: Z3_ast_int): Z3_ast_int"><wbr />`+`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%2F.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`&#x2F;`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_int"><wbr />`/`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`/`(a1`gensym261503, a2`gensym261504: Z3_ast_int): Z3_ast_int"><wbr />`/`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%2F.t%2CZ3_ast_int%2CT"
-    title="`&#x2F;`[T](a1: Z3_ast_int; a2: T): Z3_ast_int"><wbr />`/`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`/`[T](a1`gensym261505: Z3_ast_int; a2`gensym261506: T): Z3_ast_int"><wbr />`/`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%2F.t%2CT%2CZ3_ast_int"
-    title="`&#x2F;`[T](a1: T; a2: Z3_ast_int): Z3_ast_int"><wbr />`/`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`/`[T](a1`gensym261507: T; a2`gensym261508: Z3_ast_int): Z3_ast_int"><wbr />`/`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%2A.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`*`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_int"><wbr />`*`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`*`(a1`gensym261530, a2`gensym261531: Z3_ast_int): Z3_ast_int"><wbr />`*`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%2A.t%2CZ3_ast_int%2CT"
-    title="`*`[T](a1: Z3_ast_int; a2: T): Z3_ast_int"><wbr />`*`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`*`[T](a1`gensym261532: Z3_ast_int; a2`gensym261533: T): Z3_ast_int"><wbr />`*`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%2A.t%2CT%2CZ3_ast_int"
-    title="`*`[T](a1: T; a2: Z3_ast_int): Z3_ast_int"><wbr />`*`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`*`[T](a1`gensym261534: T; a2`gensym261535: Z3_ast_int): Z3_ast_int"><wbr />`*`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#-.t%2CZ3_ast_int%2CZ3_ast_int"
-    title="`-`(a1: Z3_ast_int; a2: Z3_ast_int): Z3_ast_int"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`-`(a1`gensym261557, a2`gensym261558: Z3_ast_int): Z3_ast_int"><wbr />`-`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#-.t%2CZ3_ast_int%2CT"
-    title="`-`[T](a1: Z3_ast_int; a2: T): Z3_ast_int"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`-`[T](a1`gensym261559: Z3_ast_int; a2`gensym261560: T): Z3_ast_int"><wbr />`-`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#-.t%2CT%2CZ3_ast_int"
-    title="`-`[T](a1: T; a2: Z3_ast_int): Z3_ast_int"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`-`[T](a1`gensym261561: T; a2`gensym261562: Z3_ast_int): Z3_ast_int"><wbr />`-`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#-.t%2CZ3_ast_int"
-    title="`-`(a: Z3_ast_int): Z3_ast_int"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_int</span></a></li>
+    title="`-`(a`gensym261584: Z3_ast_int): Z3_ast_int"><wbr />`-`<span class="attachedType">Z3_ast_int</span></a></li>
+  <li><a class="reference" href="#mod.t%2CZ3_ast_int%2CZ3_ast_int"
+    title="`mod`(a1`gensym261589, a2`gensym261590: Z3_ast_int): Z3_ast_int"><wbr />`mod`<span class="attachedType">Z3_ast_int</span></a></li>
+  <li><a class="reference" href="#mod.t%2CZ3_ast_int%2CT"
+    title="`mod`[T](a1`gensym261591: Z3_ast_int; a2`gensym261592: T): Z3_ast_int"><wbr />`mod`<span class="attachedType">Z3_ast_int</span></a></li>
+  <li><a class="reference" href="#mod.t%2CT%2CZ3_ast_int"
+    title="`mod`[T](a1`gensym261593: T; a2`gensym261594: Z3_ast_int): Z3_ast_int"><wbr />`mod`<span class="attachedType">Z3_ast_int</span></a></li>
+  <li><a class="reference" href="#%5E.t%2CZ3_ast_int%2CZ3_ast_int"
+    title="`^`(a1`gensym261616, a2`gensym261617: Z3_ast_int): Z3_ast_int"><wbr />`^`<span class="attachedType">Z3_ast_int</span></a></li>
+  <li><a class="reference" href="#%5E.t%2CZ3_ast_int%2CT"
+    title="`^`[T](a1`gensym261618: Z3_ast_int; a2`gensym261619: T): Z3_ast_int"><wbr />`^`<span class="attachedType">Z3_ast_int</span></a></li>
+  <li><a class="reference" href="#%5E.t%2CT%2CZ3_ast_int"
+    title="`^`[T](a1`gensym261620: T; a2`gensym261621: Z3_ast_int): Z3_ast_int"><wbr />`^`<span class="attachedType">Z3_ast_int</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`==`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`==`(a1`gensym261643, a2`gensym261644: Z3_ast_fpa): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CZ3_ast_fpa%2CT"
-    title="`==`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`==`[T](a1`gensym261645: Z3_ast_fpa; a2`gensym261646: T): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3D%3D.t%2CT%2CZ3_ast_fpa"
-    title="`==`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`==`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`==`[T](a1`gensym261647: T; a2`gensym261648: Z3_ast_fpa): Z3_ast_bool"><wbr />`==`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3E%3D.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`&gt;=`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&gt;=`(a1`gensym261670, a2`gensym261671: Z3_ast_fpa): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3E%3D.t%2CZ3_ast_fpa%2CT"
-    title="`&gt;=`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&gt;=`[T](a1`gensym261672: Z3_ast_fpa; a2`gensym261673: T): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3E%3D.t%2CT%2CZ3_ast_fpa"
-    title="`&gt;=`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&gt;=`[T](a1`gensym261674: T; a2`gensym261675: Z3_ast_fpa): Z3_ast_bool"><wbr />`&gt;=`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3E.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`&gt;`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&gt;`(a1`gensym261697, a2`gensym261698: Z3_ast_fpa): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3E.t%2CZ3_ast_fpa%2CT"
-    title="`&gt;`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&gt;`[T](a1`gensym261699: Z3_ast_fpa; a2`gensym261700: T): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3E.t%2CT%2CZ3_ast_fpa"
-    title="`&gt;`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&gt;`[T](a1`gensym261701: T; a2`gensym261702: Z3_ast_fpa): Z3_ast_bool"><wbr />`&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`&lt;-&gt;`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&lt;-&gt;`(a1`gensym261724, a2`gensym261725: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_fpa%2CT"
-    title="`&lt;-&gt;`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym261726: Z3_ast_fpa; a2`gensym261727: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CT%2CZ3_ast_fpa"
-    title="`&lt;-&gt;`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym261728: T; a2`gensym261729: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C%3D.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`&lt;=`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&lt;=`(a1`gensym261751, a2`gensym261752: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3C%3D.t%2CZ3_ast_fpa%2CT"
-    title="`&lt;=`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&lt;=`[T](a1`gensym261753: Z3_ast_fpa; a2`gensym261754: T): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3C%3D.t%2CT%2CZ3_ast_fpa"
-    title="`&lt;=`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;=`[T](a1`gensym261755: T; a2`gensym261756: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;=`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`&lt;`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&lt;`(a1`gensym261778, a2`gensym261779: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3C.t%2CZ3_ast_fpa%2CT"
-    title="`&lt;`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&lt;`[T](a1`gensym261780: Z3_ast_fpa; a2`gensym261781: T): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3C.t%2CT%2CZ3_ast_fpa"
-    title="`&lt;`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;`[T](a1`gensym261782: T; a2`gensym261783: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_fpa%2CZ3_ast_fpa_2"
-    title="`&lt;-&gt;`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&lt;-&gt;`(a1`gensym261805, a2`gensym261806: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CZ3_ast_fpa%2CT_2"
-    title="`&lt;-&gt;`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym261807: Z3_ast_fpa; a2`gensym261808: T): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%3C-%3E.t%2CT%2CZ3_ast_fpa_2"
-    title="`&lt;-&gt;`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
+    title="`&lt;-&gt;`[T](a1`gensym261809: T; a2`gensym261810: Z3_ast_fpa): Z3_ast_bool"><wbr />`&lt;-&gt;`<span class="attachedType">Z3_ast_bool</span></a></li>
   <li><a class="reference" href="#%2B.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`+`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_fpa"><wbr />`+`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`+`(a1`gensym261832, a2`gensym261833: Z3_ast_fpa): Z3_ast_fpa"><wbr />`+`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%2B.t%2CZ3_ast_fpa%2CT"
-    title="`+`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_fpa"><wbr />`+`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`+`[T](a1`gensym261834: Z3_ast_fpa; a2`gensym261835: T): Z3_ast_fpa"><wbr />`+`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%2B.t%2CT%2CZ3_ast_fpa"
-    title="`+`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_fpa"><wbr />`+`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`+`[T](a1`gensym261836: T; a2`gensym261837: Z3_ast_fpa): Z3_ast_fpa"><wbr />`+`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%2F.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`&#x2F;`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_fpa"><wbr />`/`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`/`(a1`gensym261859, a2`gensym261860: Z3_ast_fpa): Z3_ast_fpa"><wbr />`/`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%2F.t%2CZ3_ast_fpa%2CT"
-    title="`&#x2F;`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_fpa"><wbr />`/`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`/`[T](a1`gensym261861: Z3_ast_fpa; a2`gensym261862: T): Z3_ast_fpa"><wbr />`/`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%2F.t%2CT%2CZ3_ast_fpa"
-    title="`&#x2F;`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_fpa"><wbr />`/`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`/`[T](a1`gensym261863: T; a2`gensym261864: Z3_ast_fpa): Z3_ast_fpa"><wbr />`/`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%2A.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`*`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_fpa"><wbr />`*`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`*`(a1`gensym261886, a2`gensym261887: Z3_ast_fpa): Z3_ast_fpa"><wbr />`*`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%2A.t%2CZ3_ast_fpa%2CT"
-    title="`*`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_fpa"><wbr />`*`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`*`[T](a1`gensym261888: Z3_ast_fpa; a2`gensym261889: T): Z3_ast_fpa"><wbr />`*`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#%2A.t%2CT%2CZ3_ast_fpa"
-    title="`*`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_fpa"><wbr />`*`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`*`[T](a1`gensym261890: T; a2`gensym261891: Z3_ast_fpa): Z3_ast_fpa"><wbr />`*`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#-.t%2CZ3_ast_fpa%2CZ3_ast_fpa"
-    title="`-`(a1: Z3_ast_fpa; a2: Z3_ast_fpa): Z3_ast_fpa"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`-`(a1`gensym261913, a2`gensym261914: Z3_ast_fpa): Z3_ast_fpa"><wbr />`-`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#-.t%2CZ3_ast_fpa%2CT"
-    title="`-`[T](a1: Z3_ast_fpa; a2: T): Z3_ast_fpa"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`-`[T](a1`gensym261915: Z3_ast_fpa; a2`gensym261916: T): Z3_ast_fpa"><wbr />`-`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#-.t%2CT%2CZ3_ast_fpa"
-    title="`-`[T](a1: T; a2: Z3_ast_fpa): Z3_ast_fpa"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`-`[T](a1`gensym261917: T; a2`gensym261918: Z3_ast_fpa): Z3_ast_fpa"><wbr />`-`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#abs.t%2CZ3_ast_fpa"
-    title="abs(a: Z3_ast_fpa): Z3_ast_fpa"><wbr />abs<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="abs(a`gensym261940: Z3_ast_fpa): Z3_ast_fpa"><wbr />abs<span class="attachedType">Z3_ast_fpa</span></a></li>
+  <li><a class="reference" href="#sqrt.t%2CZ3_ast_fpa"
+    title="sqrt(a`gensym261945: Z3_ast_fpa): Z3_ast_fpa"><wbr />sqrt<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#-.t%2CZ3_ast_fpa"
-    title="`-`(a: Z3_ast_fpa): Z3_ast_fpa"><wbr />`-`<span class="attachedType" style="visibility:hidden">Z3_ast_fpa</span></a></li>
+    title="`-`(a`gensym261950: Z3_ast_fpa): Z3_ast_fpa"><wbr />`-`<span class="attachedType">Z3_ast_fpa</span></a></li>
   <li><a class="reference" href="#distinc.t%2Cvarargs%5BT%5D"
-    title="distinc[T](vs: varargs[T]): Z3_ast_bool"><wbr />distinc<span class="attachedType" style="visibility:hidden">Z3_ast_bool</span></a></li>
-  <li><a class="reference" href="#If.t%2CT1%2CT2%2CT3"
-    title="If[T1; T2; T3](v1: T1; v2: T2; v3: T3): Z3_ast"><wbr />If<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="distinc[T](vs: varargs[T]): Z3_ast_bool"><wbr />distinc<span class="attachedType">Z3_ast_bool</span></a></li>
+  <li><a class="reference" href="#ite.t%2C%2CT%2CT"
+    title="ite[T; ](v1: bool | Z3_ast_bool; v2, v3: T): T"><wbr />ite<span class="attachedType">Z3_ast_bool</span></a></li>
+  <li><a class="reference" href="#exists.t%2CopenArray%5BZ3_ast_any%5D%2CZ3_ast_bool"
+    title="exists(vs: openArray[Z3_ast_any]; body: Z3_ast_bool): Z3_ast_bool"><wbr />exists<span class="attachedType">Z3_ast_bool</span></a></li>
+  <li><a class="reference" href="#%E2%88%83.t%2CopenArray%5BZ3_ast_any%5D%2CZ3_ast_bool"
+    title="∃(vs: openArray[Z3_ast_any]; body: Z3_ast_bool): Z3_ast_bool"><wbr />∃<span class="attachedType">Z3_ast_bool</span></a></li>
+  <li><a class="reference" href="#forall.t%2CopenArray%5BZ3_ast_any%5D%2CZ3_ast_bool"
+    title="forall(vs: openArray[Z3_ast_any]; body: Z3_ast_bool): Z3_ast_bool"><wbr />forall<span class="attachedType">Z3_ast_bool</span></a></li>
+  <li><a class="reference" href="#%E2%88%80.t%2CopenArray%5BZ3_ast_any%5D%2CZ3_ast_bool"
+    title="∀(vs: openArray[Z3_ast_any]; body: Z3_ast_bool): Z3_ast_bool"><wbr />∀<span class="attachedType">Z3_ast_bool</span></a></li>
 
+  </ul>
+</li>
+<li>
+  <a class="reference reference-toplevel" href="#19" id="69">Exports</a>
+  <ul class="simple simple-toc-section">
+    
   </ul>
 </li>
 
@@ -1206,6 +1276,7 @@ function main() {
   </div>
   <div class="nine columns" id="content">
   <div id="tocRoot"></div>
+  
   <p class="module-desc">
 <h1><a class="toc-backref" id="z3" href="#z3">Z3</a></h1><p>This library provides a Nim binding to the Z3 theorem prover.</p>
 
@@ -1247,12 +1318,7 @@ function main() {
     <span class="Identifier">echo</span> <span class="Identifier">model</span></pre><p>More examples are available in the nimble tests at <a class="reference external" href="https://github.com/zevv/nimz3/blob/master/tests/test1.nim">https://github.com/zevv/nimz3/blob/master/tests/test1.nim</a></p>
 <p>For more info on Z3 check the official guide at <a class="reference external" href="https://rise4fun.com/z3/tutorialcontent/guide">https://rise4fun.com/z3/tutorialcontent/guide</a></p>
 </p>
-  <div class="section" id="5">
-<h1><a class="toc-backref" href="#5">Exports</a></h1>
-<dl class="item">
-<a href="z3_api.html#Z3_ast"><span class="Identifier">Z3_ast</span></a>
-</dl></div>
-<div class="section" id="6">
+  <div class="section" id="6">
 <h1><a class="toc-backref" href="#6">Imports</a></h1>
 <dl class="item">
 <a class="reference external" href="z3_api.html">z3_api</a>
@@ -1264,6 +1330,7 @@ function main() {
 <dt><pre><a href="z3.html#Z3Exception"><span class="Identifier">Z3Exception</span></a> <span class="Other">=</span> <span class="Keyword">object</span> <span class="Keyword">of</span> <span class="Identifier">Exception</span>
   </pre></dt>
 <dd>
+
 Exception thrown from the Z3 error handler. The exception message is generated by the Z3 library and states the reason for the error
 
 </dd>
@@ -1272,10 +1339,12 @@ Exception thrown from the Z3 error handler. The exception message is generated b
 <dd>
 
 
+
 </dd>
 <a id="Z3_ast_bv"></a>
 <dt><pre><a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a> <span class="Other">=</span> <span class="Keyword">distinct</span> <a href="z3_api.html#Z3_ast"><span class="Identifier">Z3_ast</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
@@ -1284,11 +1353,29 @@ Exception thrown from the Z3 error handler. The exception message is generated b
 <dd>
 
 
+
 </dd>
 <a id="Z3_ast_fpa"></a>
 <dt><pre><a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a> <span class="Other">=</span> <span class="Keyword">distinct</span> <a href="z3_api.html#Z3_ast"><span class="Identifier">Z3_ast</span></a></pre></dt>
 <dd>
 
+
+
+</dd>
+
+</dl></div>
+<div class="section" id="17">
+<h1><a class="toc-backref" href="#17">Macros</a></h1>
+<dl class="item">
+<a id="letZ3.m,untyped,untyped"></a>
+<dt><pre><span class="Keyword">macro</span> <a href="#letZ3.m%2Cuntyped%2Cuntyped"><span class="Identifier">letZ3</span></a><span class="Other">(</span><span class="Identifier">name</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">;</span> <span class="Identifier">sort</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span></pre></dt>
+<dd>
+
+<p>Declares a Z3 variable of any kind.</p>
+<p>The syntax is: <tt class="docutils literal"><span class="pre">letZ3 varName: sort</span></tt>, e.g.</p>
+<pre class="listing"><span class="Identifier">letZ3</span> <span class="Identifier">x</span><span class="Punctuation">:</span> <span class="Identifier">Int</span>
+<span class="Identifier">letZ3</span> <span class="Identifier">y</span><span class="Punctuation">:</span> <span class="Identifier">Bool</span>
+<span class="Identifier">letZ3</span> <span class="Identifier">z</span><span class="Punctuation">:</span> <span class="Identifier">Bv</span><span class="Punctuation">(</span><span class="DecNumber">3</span><span class="Punctuation">)</span></pre>
 
 </dd>
 
@@ -1299,43 +1386,104 @@ Exception thrown from the Z3 error handler. The exception message is generated b
 <a id="Bool.t,string"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#Bool.t%2Cstring"><span class="Identifier">Bool</span></a><span class="Other">(</span><span class="Identifier">name</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 Create a Z3 constant of the type Bool.
 
 </dd>
 <a id="Int.t,string"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#Int.t%2Cstring"><span class="Identifier">Int</span></a><span class="Other">(</span><span class="Identifier">name</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 Create a Z3 constant of the type Int.
 
 </dd>
 <a id="Bv.t,string,int"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#Bv.t%2Cstring%2Cint"><span class="Identifier">Bv</span></a><span class="Other">(</span><span class="Identifier">name</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">sz</span><span class="Other">:</span> <span class="Identifier">int</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 Create a Z3 constant of the type BV with a size of <tt class="docutils literal"><span class="pre">sz</span></tt> bits.
 
 </dd>
 <a id="Float.t,string"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#Float.t%2Cstring"><span class="Identifier">Float</span></a><span class="Other">(</span><span class="Identifier">name</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 Create a Z3 constant of the type Float.
+
+</dd>
+<a id="letBool.t"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#letBool.t"><span class="Identifier">letBool</span></a><span class="Other">(</span><span class="Identifier">args</span><span class="Other">:</span> <span class="Identifier">varargs</span><span class="Other">[</span><span class="Identifier">untyped</span><span class="Other">]</span><span class="Other">)</span></pre></dt>
+<dd>
+
+<blockquote><p><p><tt class="docutils literal"><span class="pre">letBool x</span></tt> is alias for <tt class="docutils literal"><span class="pre">let x = Bool(&quot;x&quot;)</span></tt></p>
+<p><tt class="docutils literal"><span class="pre">letBool(...): x</span></tt> is alias for <tt class="docutils literal"><span class="pre">let x = Bool(&quot;x&quot;, ...)</span></tt></p>
+</p></blockquote>
+
+
+</dd>
+<a id="letInt.t"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#letInt.t"><span class="Identifier">letInt</span></a><span class="Other">(</span><span class="Identifier">args</span><span class="Other">:</span> <span class="Identifier">varargs</span><span class="Other">[</span><span class="Identifier">untyped</span><span class="Other">]</span><span class="Other">)</span></pre></dt>
+<dd>
+
+<blockquote><p><p><tt class="docutils literal"><span class="pre">letInt x</span></tt> is alias for <tt class="docutils literal"><span class="pre">let x = Int(&quot;x&quot;)</span></tt></p>
+<p><tt class="docutils literal"><span class="pre">letInt(...): x</span></tt> is alias for <tt class="docutils literal"><span class="pre">let x = Int(&quot;x&quot;, ...)</span></tt></p>
+</p></blockquote>
+
+
+</dd>
+<a id="letBv.t"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#letBv.t"><span class="Identifier">letBv</span></a><span class="Other">(</span><span class="Identifier">args</span><span class="Other">:</span> <span class="Identifier">varargs</span><span class="Other">[</span><span class="Identifier">untyped</span><span class="Other">]</span><span class="Other">)</span></pre></dt>
+<dd>
+
+<blockquote><p><p><tt class="docutils literal"><span class="pre">letBv x</span></tt> is alias for <tt class="docutils literal"><span class="pre">let x = Bv(&quot;x&quot;)</span></tt></p>
+<p><tt class="docutils literal"><span class="pre">letBv(...): x</span></tt> is alias for <tt class="docutils literal"><span class="pre">let x = Bv(&quot;x&quot;, ...)</span></tt></p>
+</p></blockquote>
+
+
+</dd>
+<a id="letFloat.t"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#letFloat.t"><span class="Identifier">letFloat</span></a><span class="Other">(</span><span class="Identifier">args</span><span class="Other">:</span> <span class="Identifier">varargs</span><span class="Other">[</span><span class="Identifier">untyped</span><span class="Other">]</span><span class="Other">)</span></pre></dt>
+<dd>
+
+<blockquote><p><p><tt class="docutils literal"><span class="pre">letFloat x</span></tt> is alias for <tt class="docutils literal"><span class="pre">let x = Float(&quot;x&quot;)</span></tt></p>
+<p><tt class="docutils literal"><span class="pre">letFloat(...): x</span></tt> is alias for <tt class="docutils literal"><span class="pre">let x = Float(&quot;x&quot;, ...)</span></tt></p>
+</p></blockquote>
+
 
 </dd>
 <a id="$.t,Z3_ast_any"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#%24.t%2CZ3_ast_any"><span class="Identifier">`$`</span></a><span class="Other">(</span><span class="Identifier">v</span><span class="Other">:</span> <span class="Identifier">Z3_ast_any</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span></pre></dt>
 <dd>
+
 Create a string representation of the Z3 ast node
 
 </dd>
 <a id="$.t,Z3_model"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#%24.t%2CZ3_model"><span class="Identifier">`$`</span></a><span class="Other">(</span><span class="Identifier">m</span><span class="Other">:</span> <a href="z3_api.html#Z3_model"><span class="Identifier">Z3_model</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span></pre></dt>
 <dd>
+
 Create a string representation of the Z3 model
 
 </dd>
 <a id="$.t,Z3_solver"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#%24.t%2CZ3_solver"><span class="Identifier">`$`</span></a><span class="Other">(</span><span class="Identifier">m</span><span class="Other">:</span> <a href="z3_api.html#Z3_solver"><span class="Identifier">Z3_solver</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span></pre></dt>
 <dd>
+
 Create a string representation of the Z3 solver
+
+</dd>
+<a id="$.t,Z3_optimize"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%24.t%2CZ3_optimize"><span class="Identifier">`$`</span></a><span class="Other">(</span><span class="Identifier">m</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span></pre></dt>
+<dd>
+
+Create a string representation of the Z3 optimizer
+
+</dd>
+<a id="$.t,Z3_pattern"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%24.t%2CZ3_pattern"><span class="Identifier">`$`</span></a><span class="Other">(</span><span class="Identifier">m</span><span class="Other">:</span> <a href="z3_api.html#Z3_pattern"><span class="Identifier">Z3_pattern</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span></pre></dt>
+<dd>
+
+Create a string representation of the Z3 pattern
 
 </dd>
 <a id="simplify.t,Z3_ast_any"></a>
@@ -1343,34 +1491,40 @@ Create a string representation of the Z3 solver
 <dd>
 
 
+
 </dd>
 <a id="Solver.t"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#Solver.t"><span class="Identifier">Solver</span></a><span class="Other">(</span><span class="Other">)</span><span class="Other">:</span> <a href="z3_api.html#Z3_solver"><span class="Identifier">Z3_solver</span></a></pre></dt>
 <dd>
+
 Create a Z3 solver context
 
 </dd>
 <a id="assert.t,Z3_solver,Z3_ast_any"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#assert.t%2CZ3_solver%2CZ3_ast_any"><span class="Identifier">assert</span></a><span class="Other">(</span><span class="Identifier">s</span><span class="Other">:</span> <a href="z3_api.html#Z3_solver"><span class="Identifier">Z3_solver</span></a><span class="Other">;</span> <span class="Identifier">e</span><span class="Other">:</span> <span class="Identifier">Z3_ast_any</span><span class="Other">)</span></pre></dt>
 <dd>
+
 Assert hard constraint to the solver context.
 
 </dd>
 <a id="check.t,Z3_solver"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#check.t%2CZ3_solver"><span class="Identifier">check</span></a><span class="Other">(</span><span class="Identifier">s</span><span class="Other">:</span> <a href="z3_api.html#Z3_solver"><span class="Identifier">Z3_solver</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3_api.html#Z3_lbool"><span class="Identifier">Z3_lbool</span></a></pre></dt>
 <dd>
+
 Check whether the assertions in a given solver are consistent or not.
 
 </dd>
 <a id="get_model.t,Z3_solver"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#get_model.t%2CZ3_solver"><span class="Identifier">get_model</span></a><span class="Other">(</span><span class="Identifier">s</span><span class="Other">:</span> <a href="z3_api.html#Z3_solver"><span class="Identifier">Z3_solver</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3_api.html#Z3_model"><span class="Identifier">Z3_model</span></a></pre></dt>
 <dd>
+
 Retrieve the model for the last solver.check
 
 </dd>
 <a id="push.t,Z3_solver,untyped"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#push.t%2CZ3_solver%2Cuntyped"><span class="Identifier">push</span></a><span class="Other">(</span><span class="Identifier">s</span><span class="Other">:</span> <a href="z3_api.html#Z3_solver"><span class="Identifier">Z3_solver</span></a><span class="Other">;</span> <span class="Identifier">code</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span></pre></dt>
 <dd>
+
 Create a backtracking point. This is to be used as a block scope template, so the state pop will by automatically generated when leaving the scope:<pre class="listing"><span class="Identifier">z3</span><span class="Punctuation">:</span>
   <span class="Keyword">let</span> <span class="Identifier">s</span> <span class="Operator">=</span> <span class="Identifier">Solver</span><span class="Punctuation">(</span><span class="Punctuation">)</span>
   <span class="Identifier">s</span><span class="Operator">.</span><span class="Identifier">assert</span> <span class="Operator">...</span>
@@ -1383,36 +1537,63 @@ Create a backtracking point. This is to be used as a block scope template, so th
 <a id="check_model.t,Z3_solver,untyped"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#check_model.t%2CZ3_solver%2Cuntyped"><span class="Identifier">check_model</span></a><span class="Other">(</span><span class="Identifier">s</span><span class="Other">:</span> <a href="z3_api.html#Z3_solver"><span class="Identifier">Z3_solver</span></a><span class="Other">;</span> <span class="Identifier">code</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span></pre></dt>
 <dd>
+
 A helper block-scope template that combines <tt class="docutils literal"><span class="pre">check</span></tt> and <tt class="docutils literal"><span class="pre">get_model</span></tt>. If the solver was consistent the model is available in the variable <tt class="docutils literal"><span class="pre">model</span></tt> inside the block scope. If the solver failed a Z3Exception will be thrown.
 
 </dd>
 <a id="Optimizer.t"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#Optimizer.t"><span class="Identifier">Optimizer</span></a><span class="Other">(</span><span class="Other">)</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a></pre></dt>
 <dd>
+
 Create a Z3 optimizer
 
 </dd>
-<a id="minimize.t,Z3_optimize,Z3_ast"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#minimize.t%2CZ3_optimize%2CZ3_ast"><span class="Identifier">minimize</span></a><span class="Other">(</span><span class="Identifier">o</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">;</span> <span class="Identifier">e</span><span class="Other">:</span> <a href="z3_api.html#Z3_ast"><span class="Identifier">Z3_ast</span></a><span class="Other">)</span></pre></dt>
+<a id="minimize.t,Z3_optimize,Z3_ast_any"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#minimize.t%2CZ3_optimize%2CZ3_ast_any"><span class="Identifier">minimize</span></a><span class="Other">(</span><span class="Identifier">o</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">;</span> <span class="Identifier">e</span><span class="Other">:</span> <span class="Identifier">Z3_ast_any</span><span class="Other">)</span></pre></dt>
 <dd>
+
 Add a minimization constraint.
 
 </dd>
-<a id="maximize.t,Z3_optimize,Z3_ast"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#maximize.t%2CZ3_optimize%2CZ3_ast"><span class="Identifier">maximize</span></a><span class="Other">(</span><span class="Identifier">o</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">;</span> <span class="Identifier">e</span><span class="Other">:</span> <a href="z3_api.html#Z3_ast"><span class="Identifier">Z3_ast</span></a><span class="Other">)</span></pre></dt>
+<a id="maximize.t,Z3_optimize,Z3_ast_any"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#maximize.t%2CZ3_optimize%2CZ3_ast_any"><span class="Identifier">maximize</span></a><span class="Other">(</span><span class="Identifier">o</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">;</span> <span class="Identifier">e</span><span class="Other">:</span> <span class="Identifier">Z3_ast_any</span><span class="Other">)</span></pre></dt>
 <dd>
+
 Add a maximization constraint.
 
 </dd>
-<a id="assert.t,Z3_optimize,Z3_ast"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#assert.t%2CZ3_optimize%2CZ3_ast"><span class="Identifier">assert</span></a><span class="Other">(</span><span class="Identifier">o</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">;</span> <span class="Identifier">e</span><span class="Other">:</span> <a href="z3_api.html#Z3_ast"><span class="Identifier">Z3_ast</span></a><span class="Other">)</span></pre></dt>
+<a id="assert.t,Z3_optimize,Z3_ast_any"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#assert.t%2CZ3_optimize%2CZ3_ast_any"><span class="Identifier">assert</span></a><span class="Other">(</span><span class="Identifier">o</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">;</span> <span class="Identifier">e</span><span class="Other">:</span> <span class="Identifier">Z3_ast_any</span><span class="Other">)</span></pre></dt>
 <dd>
+
 Assert hard constraint to the optimization context.
+
+</dd>
+<a id="check.t,Z3_optimize"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#check.t%2CZ3_optimize"><span class="Identifier">check</span></a><span class="Other">(</span><span class="Identifier">s</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3_api.html#Z3_lbool"><span class="Identifier">Z3_lbool</span></a></pre></dt>
+<dd>
+
+Check whether the assertions in a given optimize are consistent or not.
+
+</dd>
+<a id="get_model.t,Z3_optimize"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#get_model.t%2CZ3_optimize"><span class="Identifier">get_model</span></a><span class="Other">(</span><span class="Identifier">s</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3_api.html#Z3_model"><span class="Identifier">Z3_model</span></a></pre></dt>
+<dd>
+
+Retrieve the model for the last optimize.check
+
+</dd>
+<a id="check_model.t,Z3_optimize,untyped"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#check_model.t%2CZ3_optimize%2Cuntyped"><span class="Identifier">check_model</span></a><span class="Other">(</span><span class="Identifier">s</span><span class="Other">:</span> <a href="z3_api.html#Z3_optimize"><span class="Identifier">Z3_optimize</span></a><span class="Other">;</span> <span class="Identifier">code</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span></pre></dt>
+<dd>
+
+
 
 </dd>
 <a id="eval.t,Z3_ast_any"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#eval.t%2CZ3_ast_any"><span class="Identifier">eval</span></a><span class="Other">(</span><span class="Identifier">v</span><span class="Other">:</span> <span class="Identifier">Z3_ast_any</span><span class="Other">)</span><span class="Other">:</span> <a href="z3_api.html#Z3_ast"><span class="Identifier">Z3_ast</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
@@ -1421,952 +1602,1160 @@ Assert hard constraint to the optimization context.
 <dd>
 
 
+
 </dd>
 <a id="evalFloat.t,Z3_ast_any"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#evalFloat.t%2CZ3_ast_any"><span class="Identifier">evalFloat</span></a><span class="Other">(</span><span class="Identifier">v</span><span class="Other">:</span> <span class="Identifier">Z3_ast_any</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">float</span></pre></dt>
 <dd>
 
 
+
 </dd>
 <a id="z3.t,untyped"></a>
 <dt><pre><span class="Keyword">template</span> <a href="#z3.t%2Cuntyped"><span class="Identifier">z3</span></a><span class="Other">(</span><span class="Identifier">code</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span></pre></dt>
 <dd>
+
 The main Z3 context template. This template creates an implicit Z3_context which all other API functions need. Z3 errors are caught and throw a Z3Exception
 
 </dd>
 <a id="and.t,Z3_ast_bool,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`and`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`and`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260516</span><span class="Other">,</span> <span class="Identifier">a2`gensym260517</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="and.t,Z3_ast_bool,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CZ3_ast_bool%2CT"><span class="Identifier">`and`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CZ3_ast_bool%2CT"><span class="Identifier">`and`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260518</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260519</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="and.t,T,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CT%2CZ3_ast_bool"><span class="Identifier">`and`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CT%2CZ3_ast_bool"><span class="Identifier">`and`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260520</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260521</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="or.t,Z3_ast_bool,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`or`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`or`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260543</span><span class="Other">,</span> <span class="Identifier">a2`gensym260544</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="or.t,Z3_ast_bool,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CZ3_ast_bool%2CT"><span class="Identifier">`or`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CZ3_ast_bool%2CT"><span class="Identifier">`or`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260545</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260546</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="or.t,T,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CT%2CZ3_ast_bool"><span class="Identifier">`or`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CT%2CZ3_ast_bool"><span class="Identifier">`or`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260547</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260548</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="xor.t,Z3_ast_bool,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`xor`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`xor`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260570</span><span class="Other">,</span> <span class="Identifier">a2`gensym260571</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="xor.t,Z3_ast_bool,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CZ3_ast_bool%2CT"><span class="Identifier">`xor`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CZ3_ast_bool%2CT"><span class="Identifier">`xor`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260572</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260573</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="xor.t,T,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CT%2CZ3_ast_bool"><span class="Identifier">`xor`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CT%2CZ3_ast_bool"><span class="Identifier">`xor`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260574</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260575</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,Z3_ast_bool,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260597</span><span class="Other">,</span> <span class="Identifier">a2`gensym260598</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,Z3_ast_bool,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_bool%2CT"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_bool%2CT"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260599</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260600</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,T,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CT%2CZ3_ast_bool"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CT%2CZ3_ast_bool"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260601</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260602</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_bool,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_bool%2CZ3_ast_bool"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260624</span><span class="Other">,</span> <span class="Identifier">a2`gensym260625</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_bool,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_bool%2CT"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_bool%2CT"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260626</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260627</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,T,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_bool"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_bool"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260628</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260629</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="not.t,Z3_ast_bool"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#not.t%2CZ3_ast_bool"><span class="Identifier">`not`</span></a><span class="Other">(</span><span class="Identifier">a</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#not.t%2CZ3_ast_bool"><span class="Identifier">`not`</span></a><span class="Other">(</span><span class="Identifier">a`gensym260651</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="and.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`and`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`and`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260656</span><span class="Other">,</span> <span class="Identifier">a2`gensym260657</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="and.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CZ3_ast_bv%2CT"><span class="Identifier">`and`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CZ3_ast_bv%2CT"><span class="Identifier">`and`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260658</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260659</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="and.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CT%2CZ3_ast_bv"><span class="Identifier">`and`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#and.t%2CT%2CZ3_ast_bv"><span class="Identifier">`and`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260660</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260661</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="mod.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#mod.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`mod`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#mod.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`mod`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260683</span><span class="Other">,</span> <span class="Identifier">a2`gensym260684</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="mod.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#mod.t%2CZ3_ast_bv%2CT"><span class="Identifier">`mod`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#mod.t%2CZ3_ast_bv%2CT"><span class="Identifier">`mod`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260685</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260686</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="mod.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#mod.t%2CT%2CZ3_ast_bv"><span class="Identifier">`mod`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#mod.t%2CT%2CZ3_ast_bv"><span class="Identifier">`mod`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260687</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260688</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="nor.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#nor.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">nor</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#nor.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">nor</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260710</span><span class="Other">,</span> <span class="Identifier">a2`gensym260711</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="nor.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#nor.t%2CZ3_ast_bv%2CT"><span class="Identifier">nor</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#nor.t%2CZ3_ast_bv%2CT"><span class="Identifier">nor</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260712</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260713</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="nor.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#nor.t%2CT%2CZ3_ast_bv"><span class="Identifier">nor</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#nor.t%2CT%2CZ3_ast_bv"><span class="Identifier">nor</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260714</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260715</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="or.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`or`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`or`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260737</span><span class="Other">,</span> <span class="Identifier">a2`gensym260738</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="or.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CZ3_ast_bv%2CT"><span class="Identifier">`or`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CZ3_ast_bv%2CT"><span class="Identifier">`or`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260739</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260740</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="or.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CT%2CZ3_ast_bv"><span class="Identifier">`or`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#or.t%2CT%2CZ3_ast_bv"><span class="Identifier">`or`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260741</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260742</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="shl.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#shl.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`shl`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#shl.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`shl`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260764</span><span class="Other">,</span> <span class="Identifier">a2`gensym260765</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="shl.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#shl.t%2CZ3_ast_bv%2CT"><span class="Identifier">`shl`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#shl.t%2CZ3_ast_bv%2CT"><span class="Identifier">`shl`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260766</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260767</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="shl.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#shl.t%2CT%2CZ3_ast_bv"><span class="Identifier">`shl`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#shl.t%2CT%2CZ3_ast_bv"><span class="Identifier">`shl`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260768</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260769</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="shr.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#shr.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`shr`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#shr.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`shr`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260791</span><span class="Other">,</span> <span class="Identifier">a2`gensym260792</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="shr.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#shr.t%2CZ3_ast_bv%2CT"><span class="Identifier">`shr`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#shr.t%2CZ3_ast_bv%2CT"><span class="Identifier">`shr`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260793</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260794</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="shr.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#shr.t%2CT%2CZ3_ast_bv"><span class="Identifier">`shr`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#shr.t%2CT%2CZ3_ast_bv"><span class="Identifier">`shr`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260795</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260796</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="xnor.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#xnor.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">xnor</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#xnor.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">xnor</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260818</span><span class="Other">,</span> <span class="Identifier">a2`gensym260819</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="xnor.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#xnor.t%2CZ3_ast_bv%2CT"><span class="Identifier">xnor</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#xnor.t%2CZ3_ast_bv%2CT"><span class="Identifier">xnor</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260820</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260821</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="xnor.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#xnor.t%2CT%2CZ3_ast_bv"><span class="Identifier">xnor</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#xnor.t%2CT%2CZ3_ast_bv"><span class="Identifier">xnor</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260822</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260823</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="xor.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`xor`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`xor`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260845</span><span class="Other">,</span> <span class="Identifier">a2`gensym260846</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="xor.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CZ3_ast_bv%2CT"><span class="Identifier">`xor`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CZ3_ast_bv%2CT"><span class="Identifier">`xor`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260847</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260848</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="xor.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CT%2CZ3_ast_bv"><span class="Identifier">`xor`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#xor.t%2CT%2CZ3_ast_bv"><span class="Identifier">`xor`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260849</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260850</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">=.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&gt;=`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&gt;=`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260872</span><span class="Other">,</span> <span class="Identifier">a2`gensym260873</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">=.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260874</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260875</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">=.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260876</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260877</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260899</span><span class="Other">,</span> <span class="Identifier">a2`gensym260900</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260901</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260902</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260903</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260904</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<=.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&lt;=`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&lt;=`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260926</span><span class="Other">,</span> <span class="Identifier">a2`gensym260927</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<=.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260928</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260929</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<=.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260930</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260931</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&lt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&lt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260953</span><span class="Other">,</span> <span class="Identifier">a2`gensym260954</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260955</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260956</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260957</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260958</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%>=.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3E%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`%&gt;=`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id=">=%.t,Z3_ast_bv,Z3_ast_bv"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D%25.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&gt;=%`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym260980</span><span class="Other">,</span> <span class="Identifier">a2`gensym260981</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%>=.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3E%3D.t%2CZ3_ast_bv%2CT"><span class="Identifier">`%&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id=">=%.t,Z3_ast_bv,T"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D%25.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&gt;=%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260982</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym260983</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%>=.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3E%3D.t%2CT%2CZ3_ast_bv"><span class="Identifier">`%&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id=">=%.t,T,Z3_ast_bv"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D%25.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&gt;=%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym260984</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym260985</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%>.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3E.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`%&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id=">%.t,Z3_ast_bv,Z3_ast_bv"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%25.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&gt;%`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261007</span><span class="Other">,</span> <span class="Identifier">a2`gensym261008</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%>.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3E.t%2CZ3_ast_bv%2CT"><span class="Identifier">`%&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id=">%.t,Z3_ast_bv,T"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%25.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&gt;%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261009</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261010</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%>.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3E.t%2CT%2CZ3_ast_bv"><span class="Identifier">`%&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id=">%.t,T,Z3_ast_bv"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%25.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&gt;%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261011</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261012</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%<=.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3C%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`%&lt;=`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id="<=%.t,Z3_ast_bv,Z3_ast_bv"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D%25.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&lt;=%`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261034</span><span class="Other">,</span> <span class="Identifier">a2`gensym261035</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%<=.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3C%3D.t%2CZ3_ast_bv%2CT"><span class="Identifier">`%&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id="<=%.t,Z3_ast_bv,T"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D%25.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&lt;=%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261036</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261037</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%<=.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3C%3D.t%2CT%2CZ3_ast_bv"><span class="Identifier">`%&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id="<=%.t,T,Z3_ast_bv"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D%25.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&lt;=%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261038</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261039</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%<.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3C.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`%&lt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id="<%.t,Z3_ast_bv,Z3_ast_bv"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%25.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&lt;%`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261061</span><span class="Other">,</span> <span class="Identifier">a2`gensym261062</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%<.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3C.t%2CZ3_ast_bv%2CT"><span class="Identifier">`%&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id="<%.t,Z3_ast_bv,T"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%25.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&lt;%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261063</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261064</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
-<a id="%<.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%25%3C.t%2CT%2CZ3_ast_bv"><span class="Identifier">`%&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<a id="<%.t,T,Z3_ast_bv"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%25.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&lt;%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261065</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261066</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261088</span><span class="Other">,</span> <span class="Identifier">a2`gensym261089</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_bv%2CT"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_bv%2CT"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261090</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261091</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CT%2CZ3_ast_bv"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CT%2CZ3_ast_bv"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261092</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261093</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261115</span><span class="Other">,</span> <span class="Identifier">a2`gensym261116</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261117</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261118</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261119</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261120</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="+.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`+`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`+`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261142</span><span class="Other">,</span> <span class="Identifier">a2`gensym261143</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="+.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_bv%2CT"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_bv%2CT"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261144</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261145</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="+.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CT%2CZ3_ast_bv"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CT%2CZ3_ast_bv"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261146</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261147</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="*.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`*`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`*`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261169</span><span class="Other">,</span> <span class="Identifier">a2`gensym261170</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="*.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_bv%2CT"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_bv%2CT"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261171</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261172</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="*.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CT%2CZ3_ast_bv"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CT%2CZ3_ast_bv"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261173</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261174</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`/`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`/`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261196</span><span class="Other">,</span> <span class="Identifier">a2`gensym261197</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_bv%2CT"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_bv%2CT"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261198</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261199</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CT%2CZ3_ast_bv"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CT%2CZ3_ast_bv"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261200</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261201</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261223</span><span class="Other">,</span> <span class="Identifier">a2`gensym261224</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_bv%2CT"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_bv%2CT"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261225</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261226</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CT%2CZ3_ast_bv"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CT%2CZ3_ast_bv"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261227</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261228</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/%.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F%25.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`/%`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F%25.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`/%`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261250</span><span class="Other">,</span> <span class="Identifier">a2`gensym261251</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/%.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F%25.t%2CZ3_ast_bv%2CT"><span class="Identifier">`/%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F%25.t%2CZ3_ast_bv%2CT"><span class="Identifier">`/%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261252</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261253</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/%.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F%25.t%2CT%2CZ3_ast_bv"><span class="Identifier">`/%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F%25.t%2CT%2CZ3_ast_bv"><span class="Identifier">`/%`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261254</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261255</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="&.t,Z3_ast_bv,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%26.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&amp;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%26.t%2CZ3_ast_bv%2CZ3_ast_bv"><span class="Identifier">`&amp;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261277</span><span class="Other">,</span> <span class="Identifier">a2`gensym261278</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="&.t,Z3_ast_bv,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%26.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&amp;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%26.t%2CZ3_ast_bv%2CT"><span class="Identifier">`&amp;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261279</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261280</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="&.t,T,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%26.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&amp;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%26.t%2CT%2CZ3_ast_bv"><span class="Identifier">`&amp;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261281</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261282</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="not.t,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#not.t%2CZ3_ast_bv"><span class="Identifier">`not`</span></a><span class="Other">(</span><span class="Identifier">a</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#not.t%2CZ3_ast_bv"><span class="Identifier">`not`</span></a><span class="Other">(</span><span class="Identifier">a`gensym261304</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,Z3_ast_bv"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_bv"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_bv"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a`gensym261309</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bv"><span class="Identifier">Z3_ast_bv</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261314</span><span class="Other">,</span> <span class="Identifier">a2`gensym261315</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_int%2CT"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_int%2CT"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261316</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261317</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CT%2CZ3_ast_int"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CT%2CZ3_ast_int"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261318</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261319</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">=.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&gt;=`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&gt;=`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261341</span><span class="Other">,</span> <span class="Identifier">a2`gensym261342</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">=.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_int%2CT"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_int%2CT"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261343</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261344</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">=.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CT%2CZ3_ast_int"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CT%2CZ3_ast_int"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261345</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261346</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261368</span><span class="Other">,</span> <span class="Identifier">a2`gensym261369</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_int%2CT"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_int%2CT"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261370</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261371</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CT%2CZ3_ast_int"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CT%2CZ3_ast_int"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261372</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261373</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261395</span><span class="Other">,</span> <span class="Identifier">a2`gensym261396</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_int%2CT"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_int%2CT"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261397</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261398</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_int"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_int"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261399</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261400</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<=.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&lt;=`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&lt;=`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261422</span><span class="Other">,</span> <span class="Identifier">a2`gensym261423</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<=.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_int%2CT"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_int%2CT"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261424</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261425</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<=.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CT%2CZ3_ast_int"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CT%2CZ3_ast_int"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261426</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261427</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&lt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`&lt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261449</span><span class="Other">,</span> <span class="Identifier">a2`gensym261450</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_int%2CT"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_int%2CT"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261451</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261452</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CT%2CZ3_ast_int"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CT%2CZ3_ast_int"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261453</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261454</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="+.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`+`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`+`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261476</span><span class="Other">,</span> <span class="Identifier">a2`gensym261477</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="+.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_int%2CT"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_int%2CT"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261478</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261479</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="+.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CT%2CZ3_ast_int"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CT%2CZ3_ast_int"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261480</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261481</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`/`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`/`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261503</span><span class="Other">,</span> <span class="Identifier">a2`gensym261504</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_int%2CT"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_int%2CT"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261505</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261506</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CT%2CZ3_ast_int"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CT%2CZ3_ast_int"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261507</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261508</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="*.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`*`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`*`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261530</span><span class="Other">,</span> <span class="Identifier">a2`gensym261531</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="*.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_int%2CT"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_int%2CT"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261532</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261533</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="*.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CT%2CZ3_ast_int"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CT%2CZ3_ast_int"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261534</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261535</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,Z3_ast_int,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261557</span><span class="Other">,</span> <span class="Identifier">a2`gensym261558</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,Z3_ast_int,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_int%2CT"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_int%2CT"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261559</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261560</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,T,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CT%2CZ3_ast_int"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CT%2CZ3_ast_int"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261561</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261562</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,Z3_ast_int"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_int"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_int"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a`gensym261584</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
 <dd>
+
+
+
+</dd>
+<a id="mod.t,Z3_ast_int,Z3_ast_int"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#mod.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`mod`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261589</span><span class="Other">,</span> <span class="Identifier">a2`gensym261590</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="mod.t,Z3_ast_int,T"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#mod.t%2CZ3_ast_int%2CT"><span class="Identifier">`mod`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261591</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261592</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="mod.t,T,Z3_ast_int"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#mod.t%2CT%2CZ3_ast_int"><span class="Identifier">`mod`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261593</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261594</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="^.t,Z3_ast_int,Z3_ast_int"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%5E.t%2CZ3_ast_int%2CZ3_ast_int"><span class="Identifier">`^`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261616</span><span class="Other">,</span> <span class="Identifier">a2`gensym261617</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="^.t,Z3_ast_int,T"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%5E.t%2CZ3_ast_int%2CT"><span class="Identifier">`^`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261618</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261619</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="^.t,T,Z3_ast_int"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%5E.t%2CT%2CZ3_ast_int"><span class="Identifier">`^`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261620</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261621</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_int"><span class="Identifier">Z3_ast_int</span></a></pre></dt>
+<dd>
+
 
 
 </dd>
 <a id="==.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261643</span><span class="Other">,</span> <span class="Identifier">a2`gensym261644</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261645</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261646</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="==.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3D%3D.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`==`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261647</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261648</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">=.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&gt;=`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&gt;=`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261670</span><span class="Other">,</span> <span class="Identifier">a2`gensym261671</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">=.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261672</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261673</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">=.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E%3D.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&gt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261674</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261675</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261697</span><span class="Other">,</span> <span class="Identifier">a2`gensym261698</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261699</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261700</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id=">.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3E.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261701</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261702</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261724</span><span class="Other">,</span> <span class="Identifier">a2`gensym261725</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261726</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261727</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261728</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261729</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<=.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&lt;=`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&lt;=`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261751</span><span class="Other">,</span> <span class="Identifier">a2`gensym261752</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<=.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261753</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261754</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<=.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C%3D.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&lt;=`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261755</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261756</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&lt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`&lt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261778</span><span class="Other">,</span> <span class="Identifier">a2`gensym261779</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261780</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261781</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`&lt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261782</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261783</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_fpa,Z3_ast_fpa_2"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_fpa%2CZ3_ast_fpa_2"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_fpa%2CZ3_ast_fpa_2"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261805</span><span class="Other">,</span> <span class="Identifier">a2`gensym261806</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,Z3_ast_fpa,T_2"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_fpa%2CT_2"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CZ3_ast_fpa%2CT_2"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261807</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261808</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="<->.t,T,Z3_ast_fpa_2"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_fpa_2"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%3C-%3E.t%2CT%2CZ3_ast_fpa_2"><span class="Identifier">`&lt;-&gt;`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261809</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261810</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="+.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`+`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`+`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261832</span><span class="Other">,</span> <span class="Identifier">a2`gensym261833</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="+.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261834</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261835</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="+.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2B.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`+`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261836</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261837</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`/`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`/`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261859</span><span class="Other">,</span> <span class="Identifier">a2`gensym261860</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261861</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261862</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="/.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2F.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`/`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261863</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261864</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="*.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`*`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`*`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261886</span><span class="Other">,</span> <span class="Identifier">a2`gensym261887</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="*.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261888</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261889</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="*.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#%2A.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`*`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261890</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261891</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,Z3_ast_fpa,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_fpa%2CZ3_ast_fpa"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a1`gensym261913</span><span class="Other">,</span> <span class="Identifier">a2`gensym261914</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,Z3_ast_fpa,T"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_fpa%2CT"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261915</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">;</span> <span class="Identifier">a2`gensym261916</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="-.t,T,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CT%2CZ3_ast_fpa"><span class="Identifier">`-`</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a1`gensym261917</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">;</span> <span class="Identifier">a2`gensym261918</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
 <a id="abs.t,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#abs.t%2CZ3_ast_fpa"><span class="Identifier">abs</span></a><span class="Other">(</span><span class="Identifier">a</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#abs.t%2CZ3_ast_fpa"><span class="Identifier">abs</span></a><span class="Other">(</span><span class="Identifier">a`gensym261940</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
+
+
+</dd>
+<a id="sqrt.t,Z3_ast_fpa"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#sqrt.t%2CZ3_ast_fpa"><span class="Identifier">sqrt</span></a><span class="Other">(</span><span class="Identifier">a`gensym261945</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dd>
+
 
 
 </dd>
 <a id="-.t,Z3_ast_fpa"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_fpa"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
+<dt><pre><span class="Keyword">template</span> <a href="#-.t%2CZ3_ast_fpa"><span class="Identifier">`-`</span></a><span class="Other">(</span><span class="Identifier">a`gensym261950</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_fpa"><span class="Identifier">Z3_ast_fpa</span></a></pre></dt>
 <dd>
+
 
 
 </dd>
@@ -2375,14 +2764,49 @@ The main Z3 context template. This template creates an implicit Z3_context which
 <dd>
 
 
+
 </dd>
-<a id="If.t,T1,T2,T3"></a>
-<dt><pre><span class="Keyword">template</span> <a href="#If.t%2CT1%2CT2%2CT3"><span class="Identifier">If</span></a><span class="Other">[</span><span class="Identifier">T1</span><span class="Other">;</span> <span class="Identifier">T2</span><span class="Other">;</span> <span class="Identifier">T3</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">v1</span><span class="Other">:</span> <span class="Identifier">T1</span><span class="Other">;</span> <span class="Identifier">v2</span><span class="Other">:</span> <span class="Identifier">T2</span><span class="Other">;</span> <span class="Identifier">v3</span><span class="Other">:</span> <span class="Identifier">T3</span><span class="Other">)</span><span class="Other">:</span> <a href="z3_api.html#Z3_ast"><span class="Identifier">Z3_ast</span></a></pre></dt>
+<a id="ite.t,,T,T"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#ite.t%2C%2CT%2CT"><span class="Identifier">ite</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">;</span> <span class="Other">]</span><span class="Other">(</span><span class="Identifier">v1</span><span class="Other">:</span> <span class="Identifier">bool</span> <span class="Operator">|</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">;</span> <span class="Identifier">v2</span><span class="Other">,</span> <span class="Identifier">v3</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">T</span></pre></dt>
 <dd>
 
 
+
+</dd>
+<a id="exists.t,openArray[Z3_ast_any],Z3_ast_bool"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#exists.t%2CopenArray%5BZ3_ast_any%5D%2CZ3_ast_bool"><span class="Identifier">exists</span></a><span class="Other">(</span><span class="Identifier">vs</span><span class="Other">:</span> <span class="Identifier">openArray</span><span class="Other">[</span><span class="Identifier">Z3_ast_any</span><span class="Other">]</span><span class="Other">;</span> <span class="Identifier">body</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="∃.t,openArray[Z3_ast_any],Z3_ast_bool"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%E2%88%83.t%2CopenArray%5BZ3_ast_any%5D%2CZ3_ast_bool"><span class="Identifier">∃</span></a><span class="Other">(</span><span class="Identifier">vs</span><span class="Other">:</span> <span class="Identifier">openArray</span><span class="Other">[</span><span class="Identifier">Z3_ast_any</span><span class="Other">]</span><span class="Other">;</span> <span class="Identifier">body</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="forall.t,openArray[Z3_ast_any],Z3_ast_bool"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#forall.t%2CopenArray%5BZ3_ast_any%5D%2CZ3_ast_bool"><span class="Identifier">forall</span></a><span class="Other">(</span><span class="Identifier">vs</span><span class="Other">:</span> <span class="Identifier">openArray</span><span class="Other">[</span><span class="Identifier">Z3_ast_any</span><span class="Other">]</span><span class="Other">;</span> <span class="Identifier">body</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="∀.t,openArray[Z3_ast_any],Z3_ast_bool"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#%E2%88%80.t%2CopenArray%5BZ3_ast_any%5D%2CZ3_ast_bool"><span class="Identifier">∀</span></a><span class="Other">(</span><span class="Identifier">vs</span><span class="Other">:</span> <span class="Identifier">openArray</span><span class="Other">[</span><span class="Identifier">Z3_ast_any</span><span class="Other">]</span><span class="Other">;</span> <span class="Identifier">body</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a><span class="Other">)</span><span class="Other">:</span> <a href="z3.html#Z3_ast_bool"><span class="Identifier">Z3_ast_bool</span></a></pre></dt>
+<dd>
+
+
+
 </dd>
 
+</dl></div>
+<div class="section" id="19">
+<h1><a class="toc-backref" href="#19">Exports</a></h1>
+<dl class="item">
+<a href="z3_api.html#Z3_ast"><span class="Identifier">Z3_ast</span></a>, <a href="z3_api.html#Z3_lbool"><span class="Identifier">Z3_lbool</span></a>
 </dl></div>
 
   </div>
@@ -2392,7 +2816,7 @@ The main Z3 context template. This template creates an implicit Z3_context which
       <div class="twelve-columns footer">
         <span class="nim-sprite"></span>
         <br/>
-        <small>Made with Nim. Generated: 2019-02-12 13:03:19 UTC</small>
+        <small>Made with Nim. Generated: 2020-03-08 18:34:47 UTC</small>
       </div>
     </div>
   </div>

--- a/src/z3.nim
+++ b/src/z3.nim
@@ -73,7 +73,12 @@
 import z3/z3_api
 from strutils import parseFloat
 from math import pow
-from macros import expectKind, getAst, nnkIdent, strVal
+from macros import
+  kind, nnkIdent, nnkStmtList,
+  len, del, `[]`,
+  strVal,
+  getAst,
+  error
 
 export Z3_ast
 export Z3_lbool
@@ -96,10 +101,9 @@ type
 
 # Z3 type constructors
 
-from macros import treeRepr, len, del, kind, `[]`, nnkStmtList, nnkIdent, expectLen, error
-
-
 macro genLet(fn: proc, args: varargs[untyped]) =
+  ## Generates `let-call for a constructor getting name of the variable
+  ## as its first argument.
   assert args.len > 0
   let lastArg = args[^1]
   args.del(args.len - 1)

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -40,6 +40,21 @@ suite "z3":
       if s.check() == Z3_L_TRUE:
         echo s.get_model()
 
+
+  test "math school problem - bit version":
+    z3:
+      let x = Bv("x", 32)
+      letBv(32): y
+      assert not compiles(letBv(32, z))
+      letBv(32): z
+      let s = Solver()
+      s.assert 3 * x + 2 * y - z == 1
+      s.assert 2 * x - 2 * y + 4 * z == -2
+      s.assert x * -1 + y / 2 - z == 0
+      echo s
+      if s.check() == Z3_L_TRUE:
+        echo s.get_model()
+
   test "XKCD restaurant order":
 
     z3:
@@ -175,7 +190,7 @@ suite "z3":
     z3:
       let s = Solver()
       letInt x
-      letInt y
+      letInt: y
       s.assert y == 20
       s.assert exists([x], x * y == 180)
       if s.check() == Z3_L_TRUE:

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -171,6 +171,16 @@ suite "z3":
       if s.check() == Z3_L_TRUE:
         echo s.get_model()
 
+  test "exists - let-syntax":
+    z3:
+      let s = Solver()
+      letInt x
+      letInt y
+      s.assert y == 20
+      s.assert exists([x], x * y == 180)
+      if s.check() == Z3_L_TRUE:
+        echo s.get_model()
+
   test "optimize":
     # Pablo buys popsicles for his friends. The store sells single popsicles
     # for $1 each, 3-popsicle boxes for $2, and 5-popsicle boxes for $3. What

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -45,8 +45,14 @@ suite "z3":
     z3:
       let x = Bv("x", 32)
       letBv(32): y
-      assert not compiles(letBv(32, z))
-      letBv(32): z
+      assert not compiles((letBv(32, q)))
+      assert not compiles((letBv("32"): q))
+      assert not compiles((letBv(x = 32): q))
+      letZ3 z: Bv(32)
+      assert not compiles((letZ3 q: Bv(32, 4)))
+      assert not compiles((letZ3 q: Bv("32")))
+      assert not compiles((letZ3 q: Bv(x = 32)))
+      assert not compiles((letZ3 q: BvX))
       let s = Solver()
       s.assert 3 * x + 2 * y - z == 1
       s.assert 2 * x - 2 * y + 4 * z == -2
@@ -189,8 +195,8 @@ suite "z3":
   test "exists - let-syntax":
     z3:
       let s = Solver()
-      letInt x
-      letInt: y
+      letInt: x
+      letZ3 y: Int
       s.assert y == 20
       s.assert exists([x], x * y == 180)
       if s.check() == Z3_L_TRUE:


### PR DESCRIPTION
Proposed answer to "open question" about Z3 consts, [mentioned in the README](https://github.com/zevv/nimz3/blob/master/README.md#open-questions):
> What is a good way to create Z3 consts? The current method of doing let x = Int "x" is redundant and prone to mistakes. Is it better to create some kind of declaration template instead?

There are two alternative syntaxes proposed here:
```nim
letInt x      # same as `let x = Int("x")`
letBv(32): y  # same as `let y = Bv("y", 32)`
```
```nim
letZ3 x: Int     # same as `let x = Int("x")`
letZ3 y: Bv(32)  # same as `let y= Bv("y", 32)`
```
The user can use the arguments' names (e.g. `letBv(sz = 32) y` or `letZ3 y: Bv(sz = 32)`) in both variants too.

The first variant is a macro generator (`wrapLet`) of templates (`letInt`, `letBv` etc) that call a macro (`genLet`) which validates syntax, parses and generates a `let` call identical to the one in the question, but injecting the stringified identifier.

The second variant is much simpler, it's a single macro that generates the whole `let` call, with a few variants depending on the grammar it finds.

Pros:
* fully eliminates redundancy
* eliminates unsafety, for the most part*
* provides documentation to the generated wrappers
* generates meaningful error messages for bad syntax calls
* conceptually trivial

Cons:
* may yield surprising results in some cases*

\* – can be surprising and/or misleading. That is because two Nim variables can have the same name if they're in different scopes/blocks. For Z3, that's only the case if their sorts/types are different (including e.g. difference between Bv-32 and Bv-64). So following these two cases:
* Z3 sort is the same – inner scope variable points to the same one in Nim. It's arguable what should be done in such a case. It can lead to some mileading results as the outer variable and the inner one can be used in a single expression:
  ```nim
  let s = Solver()
  letInt x
  letInt y
  let z = x > y
  block:
    letInt x
    s.assert z or x > y  # `(x > y) or (x > y)`
                         # same variable, simplifies to `x > y`
  ```
* Z3 sorts are different – both Nim and Z3 treat these variables as two different things:
  ```nim
  let s = Solver()
  letInt x
  letInt y
  let z = x > y
  block:
    letBool x
    s.assert z or x  # `(x_Int > y) or x_Bool`
                     # two different variables with the same name
  ```

  It's arguable if different variables with the same name are desirable at all, despite Z3 handling them just fine.

Extension
---------
The second syntax more closely matches Nim's own. It can be extended in two ways:
```nim
letZ3 x: Int                       # like `let x: int = ...`
letZ3 y: Int                       # like `let y: int = ...`
funcZ3 f(Int, Int): Bool           # like `proc f(a: int, b: int): bool = ...`
# or
letZ3 g: Function(Int, Int): Bool  # like `let f: proc(a: int, b: int): bool = ...`
s.assert f(x, y) <-> f(y, x)
```
However, it could be done by the `let`-constructors too, matching Python's API more closely:
```nim
letInt x
letInt y
letFunction(BoolSort, IntSort, IntSort) f
  # closely matches Python's `f = Function(BoolSort(), IntSort(), IntSort())`
s.assert f(x, y) <-> f(y, x)
```

The alternative syntaxes (`letInt x` and `letZ3: Int`) can coexist (just like `Int` and `letInt` do) too, although it would be simpler to only support one of them.